### PR TITLE
Fix missing image

### DIFF
--- a/examples/temporal-photon-scattering.ipynb
+++ b/examples/temporal-photon-scattering.ipynb
@@ -45,7 +45,7 @@
     "### Problem definition\n",
     "Consider an arbitrary system with a Hamiltonian $H_S(t)$ coupled to a bath of waveguide modes:\n",
     "\n",
-    "<img src=\"images/system_waveguide_coupling.png\", width=500>\n",
+    "<img src=\"attachment:./images/system_waveguide_coupling.png\", width=500>\n",
     "\n",
     "The problem we address in this notebook is this: if we drive the system with some excitation field, such as a laser pulse, how do photons scatter from the system into the waveguide?\n",
     "\n",


### PR DESCRIPTION
Link in notebook not working on Tutorials page. Works fine when running locally
Image is present.
Trying some suggestion from:
https://stackoverflow.com/questions/41598916/resize-the-image-in-jupyter-notebook-using-markdown
preceding with `attachment:`
also adding `./` to path