### PR TITLE
Added imagemagick information for display

### DIFF
--- a/examples/qip-toffoli-cnot.ipynb
+++ b/examples/qip-toffoli-cnot.ipynb
@@ -1,260 +1,301 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:6b0d8eff1aba0c80a9867a716c292342130fa3d165002e7460fe26d346cc8cb3"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Decomposition of the Toffoli gate in terms of CNOT and single-qubit rotations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Copyright (C) 2011 and later, Paul D. Nation & Robert J. Johansson"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebooks demonstrates how a toffoli gate can be rewritten in terms of CNOT gates and single qubit gates, and verifies the equivalence of the two gate sequences by comparing their matrix representations. For more information about the toffoli decomposition, see Nielsen & Chuang, Sec. 4.3, p178.\n",
+    "\n",
+    "\n",
+    "**Note: The circuit image visualizations require [ImageMagick](https://imagemagick.org/index.php) for display.**\n",
+    "\n",
+    "ImageMagick can be easily installed with the command `conda install imagemagick` if you have conda installed.\n",
+    "Otherwise, please follow the installation instructions on the ImageMagick documentation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qutip import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q = QubitCircuit(3, reverse_states=False)\n",
+    "q.add_gate(\"TOFFOLI\", controls=[0, 2], targets=[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
     {
-     "cell_type": "heading",
-     "level": 1,
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFwAAABhCAQAAADxAg6gAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NORO0dZyJAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAb1JREFUeNrt3DFq3EAUxvH/CykTyLhLFXBygXjXN9BWqTdlSvsIuoKuoDalfIRVkQMouEthWDcp0q0gXSDwUlgoEFzOg+fwfSr0UDHz4zEaVAwyp36scKQAcO9vAyYAjJ7z6qOecbHWX/hdn+07C+r4aSlnPwuYAHgWMajPXD+wl3tAQjoOYIWRxucoeEjHAXzmFMcOhEdHcMEFTxrBBRc8aQQXXPCkEVxwwZNGcMEFTxrBBRc8aQQXXPCkCYLbxlourbPNE4JbsYEO+M5MZ4OVELlXvigcaR2Hg+PQcqTUnsUD4D3dUh2We8uQHk5hWuvDWk2c14bXXuN7xkeejuyrv0mVj31s+cndUr/ndqne8YqpJtt3tZfKnv6RpdJxlX+Nr3vI+nKWiH2l8hr3mRvafx623ASco6jdCYeBgfLQcQrd330mcccB/CNfmaxnaz0T+Lb+HCEdX/re8I0manSPO9oEdvBd2OD6rBVc8KwRXHDBk0ZwwQVPGsEFFzxpBBdc8KQRXHDBk0ZwwQVPGsH/E7jt7URjx7ijTcaG+kePXvCZlwD84FME28fnNAHwNwsbXvOBXwHy8cn+7eMPHJCx3p1GnSsAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDUtMjlUMTM6NTc6MTkrMDA6MDAJo3FiAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTA1LTI5VDEzOjU3OjE5KzAwOjAweP7J3gAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNSAFXAs5AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 3,
      "metadata": {},
-     "source": [
-      "Decomposition of the Toffoli gate in terms of CNOT and single-qubit rotations"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Copyright (C) 2011 and later, Paul D. Nation & Robert J. Johansson"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "This notebooks demonstrates how a toffoli gate can be rewritten in terms of CNOT gates and single qubit gates, and verifies the equivalence of the two gate sequences by comparing their matrix representations. For more information about the toffoli decomposition, see Nielsen & Chuang, Sec. 4.3, p178."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from qutip import *"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "q = QubitCircuit(3, reverse_states=False)\n",
-      "q.add_gate(\"TOFFOLI\", controls=[0, 2], targets=[1])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "q.png"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJYAAABoCAQAAAC5kMEAAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAADWElEQVR42u2dvW4bRxRGzwQqHQSbxi4CGNhA\ntQu+wqbwA9B9gIB5BOsRmCcw5NKtCrtxJTWu0pgwXBtmlVoLw+lvCq7o/aFlfeaQuwG+w4Lcy7nD\nOwc7u0OAIxFM68Gca4KPzMauZPhIwZRIBR8pAFjHr2NX0+ckLccuocPDRhWU6Rmfxi6ny/TOrOvm\nZR0/j11Nnx/GLqBL1PwJwOfmeVJM7MwCSAV/8CFejV3HkJOxCxgSdXo3dg27mdg0nDaWJWBZApYl\nYFkCliVgWQKWJWBZApYlYFkCliVgWQKWJWBZApYlYFkCliVgWQKWJWBZApYlYFkCliVgWQKWJWBZ\nApYlYFkCliVgWQKWJWBZApYlYFkCliWQ+dfK6W/eZOjmJ8iyYeBRPM45uty/Vn4TZ5l73IPcu0c8\nDQUsS+BgmwZSwawXWkUNkCpmFNRcxBpSRdVuFGfDSNNjJ6+duWmxPb6KqwMNKvNuweX2VcWSMuAt\ny4CSc6og4JxF06J5xZygCAJKLpntiuzKC6gIytan94+XmUd3MFlPm+fLTYyCecBTLrctCq6ZbYa4\njZVUOyM78rrtdh5nlnW4a9a6dwbXFMCCi1bkgkVr4pYQ6+1+w27klrzjcTBZcTGIPE8zyo7Emnnr\naD7IayLfyDsauXeyPrr13eJrkbQEKv768kYnUtyhp53V5B3dSd5F5DeKWw2Gudo8xRmkwT1wG/lq\nXuuTy1j3Y7zPO7qjrrOi5qqzoKho3eSHN/ybyO15DUe4ih17UXrGPN1MvQraE2/PvLtNzL046E7W\ntKCkpEjLm4VirNITztPzuEoLKn6LOlXMN9O3tfjsRXbltdsBFV96+v8tSm9tNaNqLx7v3LuYl3ud\nNcoe6VgdNy8X/iItkPvMethdAHwn94B/M/RzP+/gcp9Zr7P0csppln5e5h3cBP8IxmZxcLA72h74\nmiVgWQKWJWBZApYlYFkCliVgWQKWJWBZApYlYFkCliVgWQKWJWBZApYlYFkCliVgWQKWJWBZApYl\nYFkCliVgWQKWJWBZApYlYFkCliVgWQKWJWBZApYlYFkCliUwOVlpnq655EWa7d9X9trI8SP/fNzj\nBT8C8A+/j11Mn6mdWaeNKviFB2MX02dimwam/T9Z/wMdwsqhlwCU5AAAACV0RVh0ZGF0ZTpjcmVh\ndGUAMjAxNS0wMS0xM1QxMzoyMTowMCswOTowMKIfRysAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTUt\nMDEtMTNUMTM6MjE6MDArMDk6MDDTQv+XAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkA\nAAAASUVORK5CYII=\n",
-       "prompt_number": 3,
-       "text": [
-        "<IPython.core.display.Image at 0x7f47f4731be0>"
-       ]
-      }
-     ],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U = gate_sequence_product(q.propagators())\n",
-      "\n",
-      "U.tidyup()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 4,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  1.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  0.  1.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  1.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  1.  0.  0.]]"
-       ]
-      }
-     ],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "q2 = q.resolve_gates()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "q2.png"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAABzIAAACSCAQAAACEEURXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAY0klEQVR42u3dz6sz133H8c+3PHEhGNxxoHHw\n4sI43XRj0nkW7cqhnVsIhpJQlNqQZdBDFt0YggT9B3QJdNNFeUS7a2n7iEAxLV1cUcimgfKI1NBd\na4ELhWRhT0xCF9l8u9CvkTQa6UpndEa679fF+D660mjme86ZM9+ZM2fMhWtmP9aPzv6lb/s3Ym83\nAAAAgDiexF4BNOxH3j/3V9og9kYDAAAAiOXXYq8AAAAAAOB6kGQCAAAAAIIhycQGS+v/asnGK8nm\nKwAAAAAer8D3ZEaZZqbsxt+P+v2tZol6818LjX1S+Z6B7moX0l3d42mpTyUvrGdDL2JvHeKxf9FH\nUVeAqaYAAAjO/k6fRF2Bd/z3YscAxwo98U+EaWbKmHKmjhfqm+upTyQbWNefbb7DOhrXpYsb1yxf\nWN/HkobqKWq5I7KPaPcAAFydT+jfcSyGyz4qlqmYXcH0vrqWb72h4+PaBXQ0Wi6ru/jNCxWWxd42\nAAAAAG1Akvm45JonkdZRoY0Bs5Zpuufz6WKQraWaanXNc6xO7E0DAAAA0AYkmY9LNkssLVdPt1sD\nY/NV2mkDe2kf2729tPvFYAVLS2llVr7m6RM1fiXTOvaZuX3MNdNjED0Ax2DfgeZRy4BrFPqeTLRb\nrqkNJKX+tOKvySKJtI5G3reuD63nq4mAloNlraPx1mcbZYmeK5GU6oXeihS9i0X0AByDfQeaRy0D\nrtOTwLfUvh15e95pyS3CN5Fn4yqvyZJl0uwGbru3rg93f8hHs8Gzlq4NoE18Ks2uaG5dBS3/u4lS\nuFmmsan9pT4/YwQfso4/b+2aNRs92v3Ma1JLa8D1rXXZ25FnNw6rPb3HbG3Y856qjfXzTf1v7FUo\nuYRa9pp+o1Utc1Nzteyd2FvWkv69bfvmC1hr7z8JO2tU9KoQeXbb9lkrkeUdmUq0fBqm5ZpIFXPK\ndv2Z5avksXTHZq7UckmZOqb5sNnylcwGSsESvTf/tfDvxYjkJWs6erR74Dqx50XzqGVtFr1/jzx7\nPU7BPZmPSba85zLTeHZl07rK1Vs+P3PJFmnoagba5WBZH3rf+95XotGe2WiD8UKzB64s/o8HIHoA\njsG+A82jlgHXiSTzkbDMBssrkNJEiXVUSD7Unabz80SjUkrZ1VhSUZ7Qp3y101IbSOrMlmepGk82\nfajX9fd6y0enL+vxIXoAjsG+A82jlgHXiIl/HgmfaKLVkINbZZr6VLJMqQ8t84nkE1td0Rx6IfnE\n5ucVrbP+wBOfql9aXun5mQ1uQ2GfVAzrxUGIHoBjsO9A86hlwPXhSuaj5IWPfSpZqo4yu19erxzN\nr3Qur1r64j7MrPYM4/L5mQAAAAAeN65kPmo+1doN1T6ygU22zyZa7QNKbCBuywYAAAAgiSuZ2OD9\n1byzJYl2PvDEktnQWgAAAADgSia2VA189WnN+wuRYgIAAACY40omAAAAACAYkkwAAAAAQDAMl712\nb9vg7N/5ZuyNBgAAABALSeaV82/EXgMAAAAAjwnDZQEAAAAAwZBkAgAAAACCIckEAAAAAARDkgkA\nAAAACIYkEwAAAAAQDEkmAAAAACAYkkwAAAAAQDAkmQAAAACAYEgyAQAAAADBkGQCAAAAAIIhyQQA\nAAAABEOSCQAAAAAIhiQTAAAAABAMSSYAAAAAIBiSTAAAAABAMCSZAAAAAIBgSDIBAAAAAMGQZAIA\nAAAAgiHJBAAAAAAEQ5IJAAAAAAiGJBMAAAAAEAxJJgAAAAAgGJJMAAAAAEAwJJkAAAAAgGBIMgEA\nAAAAwZBkAgAAAACCIckEAAAAAARDkgkAAAAACIYkEwAAAAAQDEkmAAAAACAYkkwAAAAAQDAkmQAA\nAACAYEgyAQAAAADBkGQCAAAAAIIhyQQAAAAABEOSCQAAAAAIhiQTAAAAABDMk9grAABtYt/XlyJ8\n7af+g4Db8Ef6v4bW84v+4VnicdEs0bv66dm/9gLLxr4TIU7VLjF6zbXz3d7wv4m93Q9l7+gLsddh\n7gKjd13sHb2nz8/+ta/4B0G3oan6HLx+kmQCQNmXvH/+L7VB0MV9S3/b0Ip+Sxd3KB7Fu/rrs3/n\nJZZNjDhVu8ToNdfOd3tXl5cmvacfxl6FuUuM3nX5gn7o43N/aeD+vbn6HLx+kmQCwLX5WVPdqOWx\nN+0SeGGfRDiQucSyiRCnahcZvcba+W4XGafPqWW4Io3V5/D1k3syAQAAAADBkGQCwIksrf+rJRuv\nJJuvAACAtqF/P15LkkyKEHh8LqHdW2KD+U/Psh3vGaioXUjXi/my5oNRvFC3bfuwqtJgT3s+l9Aa\n2qA+Trs+Q/QWkaj/K3FaxeLhnyB6G9uf1v2tDdGif2/6exu9J9Nyrcb3jmdjiC1Xvvh9+b6B7moX\n1F1MxGH57JNeWM+GXl/wACII3e4tURav3Xuhvrme+kSygXX92db2djSuW6fFbtw6SlTYvUY+lDRU\nT2eaYMgS9ea/Fhr7pPI9laXBnjaE4+Nf0l1NR2WpT89VNpaoo0x/aNLER/EjtTdO1eJG72v61wuJ\nXqQ4SdZRpj+xRBONzlAqp7fHKnGj9/v6yTmiV9XDV/Xve2NI/x5Iy/t3D/qjwca/E7kSl0s93c9/\nG6y/Sx3ltctMZu9XRx3l6qlbfrX++/m5rh/Kt53Ra7jdd9XR/fna/dbWZPps+btvr7Ve7FleV5lL\n6Xx7cn22jE12rm1wyWffpoGeV7x/Z2lsRpw2eGQtOjL+VaWgl7N3N182yvVSXaUaKNNA90qbjlN9\npPbFieidEr1ocUp0P49Rqu7ie+PF6bh6FjF6L84eva0efrN/3xfDiP17vr5e9O/N1s+Gh8t6MftP\n8jsl6la+qbNnnqSOZmcAMx/52O+UzZdc7Lq4DSCmcO3eUmU+9JHuNLAkUrvPNV9T66jQxnlCyzTd\n8/nUJ5IS9SyRfKxktg/TWJ1zbYJlKmZnOL2vbsUMcjtLgz1tCMfHf/F3La+D2bI9NV02lmmgWx/6\nVPKJ99XXi6aHV+2J1L44Eb1TohcnTonu1fe+TySf+lC3GjS9xzm5PbYmepJeaHje6AXp4enfA2pz\n/37OezILVexgDy5CqbMRijMWIYAjndbuo+6657JZx2O5errdGlqSL7olG9hL+9ju7aXdr56KZens\nfg6fuHkx68jmg4MmOl93ekpHyp72dGEOZCRZqmnpDqFmy2agb5fru090txyYFSFSB8SpGtFTi2tZ\nT3flIX5e6NsK+1TBB8Xp6HoWJXo20LCcQJwleuuO6+Evrn+v7uHp3/c5W5JpmTIN5/9IrGO5zc7q\nHViEkkZ6aQMbLJZy1iIEcIRT233kXfdMrsQGNlDXn1bc75DM1tQ6GvlT3fmtRn67ujenfH5bktQt\n3alxvqkBTuhI2dMGEORAZraktUPKBsvGck184+DER2r6OX91kco1qf9wi6KXtTl67YmTpGzzblWf\natLw8yQPbo9VHn30yrFY9fDl/n3PydfL69939vD073s0OvHPYqMkFZLeWm26jyTrKdN4owj71vWh\n9Xx1i+qqCO8kdTUtFWnLZm8CsBCs3c/E2XVLskyaT1Bwb10f7nqfj2ZnDC3dOGuYlA81rTefFmDm\nfFMc5JraQFLqTyv+uq802NOe6rT4L1uDdTTe+mxT/lh/VfHqP9k3/R8jRSqpbzGtit539cOKV1sR\nvTbFyb6p/6x4eaTvqqHHze+N05561qropfrvipebjt7su7d6+FL/vn7y9Qr69509PP37Hk8s7IX1\ntyte25pzqjr09UVoiQbq60493duiUm8v553A23OsG30SexWuchs6FnsN6tzo5/o89krUeLex6DXW\n7mf27rrDtvt31v61HIiiRKk0v/9hupg/cE3Xn1leXr/1gSrW0dRHlkrzT5Z37g1uw8kdaTnib7dk\nH1v2tj6KvQpbbla/hjqQsVTF1lnq8r/D1qFcssVAqtWSv67fsd8N+C1r+47DI2VdrU/JP/Zx66K3\nuJ7UsuidGKewe4Df1m8ul7eK02vK27A/bKCWhY3er+sPzh29cix2buVSkP49bMxu9M+lf2317w/p\n4R/Qv4fdhub695uw/bv3n3jQSXZPXr3dRbiYRrhvmp8pqcq/fxR2e9AuJsr3eM1Fr8F2rz277pmg\n7X5ja7LlUJNMfcm+p3/Xc91aV9La7twWnVReOovcWU0cbrmmPlHFAKfGt2E7UU6U+dhyTX37bo2t\nVHkt4h/RBg+xVgIVBzKz4aiL6TPW7G4NuVLLJWXqmHy7FwxbhyZKF2e7bbB8jNgLPQs55f2+mror\nTjsPpdoevb4fd19p0OidFKegewBL9HwZnVWcevpB3cHyueLUQC0LHb03K6LX1U8ajN7Dndq/h43Z\n+lDizf49U6Li4B7+8P497DY0179/Erp/P+fEP3uVinBhdVG9fHNxwJ00gLhq2/1s1z2SlIU8ODtw\nzTIbLA8apIkS6+jHSjXR6lTX6j6rrsaSivU7HBaHLZbqhV6amy+mZbC0+SFNc+WOdCzZ19XRxF5K\n2xORVJQGTrUZ/0yyrnL1Dor/sjX40Pve974SjY6aZfVhxtt1wNLKhKXBSO2KU7ULiF6Te7GDo9ee\nOHkxaw8bcjX5VNGrqWU7otc5W89ygAvr3wtN1nr48n3UFT08/fs+jSaZNrtk3ymfObBcmTLLratU\nHcsPLUIfKbXO/KzHYlhCixoSgJmQ7T7qrls+8b6/7s/mBwu3KjTx/5h3PvOhND5ZXpsa+p3kEy0f\n52yd1Q33PvXX3dzc/K35S51GD6QW61DVkf7ch0o19vH80dO1pcGe9hQ7DmTkQ91pOj9rfGBrkCRL\ny62rybLxQuOtaxjPj3hE/UmR2hmnam2K3rDF0WtNnCT1N2dDtcF83FqcOO2vZ+2PXqMJ23YPv9W/\n7zn52uL+fepFuYcv9e9bPTz9+2FhDvpzzIM8V486nT3C1LV4ZLE66mw8NDVfPc54/VGnTT1IlJ82\n/VC+7Yxes+1+43ONt/t9S1NXPXVXjzyuedBx7ZLWH5p8nm1QolypEiXqqeNaxHJ3aTT7UOnr/amO\n0yz+Lpeyw+L/kNbQwIPeB3oxe9S6S9nikenNx2kVqV1x2vUpondI9FoWp67ulc3jlOhFEyXxkDjt\nq2dE76BPvTg9Wk3ETPmu/roU0VIPT/9+2s8ZZpfda2T5fPLixVXLxVmYbH108Mb0wqlP9i8cQCsd\n3O43tKDd+50NVmf/fGQDm2yfea9/8LoNFOHeRi80lqynRFJqq6nNd5dGKyJ+LWbxlyxVR7KuRvMS\naGlr8L7lem6JvmKZCj0735C2eU3dGaedn2pj9L7atui1LE5DG6tnqd6wTNLdGQYz18dpTz1rZfQy\nvX7u6O0xj2G7onWYcg9P/36aFiSZl1SEAMK41HZvidLZVAWlbelbpqonbA1rljJs9N62Wr41aG9X\nabQh4tfIp+tRbW9r8HHMwdKHxqlaW6K3mpLlvC6olk1XNxmc32acHlbP2hK9WLVs51pVxjB+tPbZ\n7uHp30/Riol/vL8xTfRMa4sQwOkus9174X0fbc7dV3Uu0Ke7r1x4cf5pDvZsV2VptCHij8Nltobz\n2xGnakRvA7XsUA+oZ0Rvh8oYtj5aVT08/fvxWnAlU9pVhDXvL874mFMAjaDdt0llaRDxs6E1HObw\nwV1Er2K7qWUHOrSeEb2a7d+KIdGKJVb/3oormQAAAACA60CSCQAAAAAIpiXDZQGgJV7Zer7dWb71\nQrYh7HpeKUt1E6EWXWLZxIhTtUuMXox91U3sjT7Cp62pZZcYvevyRX3L9j1vN7w3gy6tufocvH6S\nZAJAiX8Qew3YhkvnU70fex0ugxOnE9DOD+M/iL0GaAv/UB/GXoeTt+GC6jPDZQEAAAAAwZBkAgAA\nAACCIckEAAAAAARDkgkAAAAACIYkEwAAAAAQDEkmAAAAACAYkkwAAAAAQDAkmQAAAACAYEgyAQAA\nAADBkGQCAAAAAIIhyQQAAAAABEOSCQAAAAAIhiQTAAAAABAMSSYAAAAAIBiSTAAAAABAMCSZAAAA\nAIBgSDIBAAAAAMGQZAIAAAAAgiHJBAAAAAAEQ5IJAAAAAAiGJBMAAAAAEAxJJgAAAAAgGJJMAAAA\nAEAwJJkAAAAAgGBIMgEAAAAAwZBkAgAAAACCIckEAAAAAARDkgkAAAAACIYkEwAAAAAQDEkmAAAA\nACAYkkwAAAAAQDAkmQAAAACAYEgyAQAAAADBkGQCAAAAAIIhyQQAAAAABEOSCQAAAAAIhiQTAAAA\nABDMk9gr0Gb25/rV2b/0Rn/m09hb/vhEKetqr/gHsVcBOA/7vr4Uex3mbvz92KsAAMD1IMms8yvv\nn/srbUCKGUWEsq5mg9hrAJzNl2h3AABcI4bLAgAAAACCIckEAAAAAARDkhmYpXV/s2TjlWTzFVyK\nupLe/RlqAHCah7c82h0AAOfGPZkHs0S9+a+Fxj6pfM9AdzWL6M7uP7JEmY8lyQvr2dCL2NuGdfvL\nek9J79Jd3YFmqU+pAcBKgH1sNdodAABnRpJ5MC/UN9dTn0g2sK4/23yHdTTefdiyOHNuHSUq7F4j\nH0oaqqeWTH3RZpaqp1RftUwT3TV9cLivrOtLeuc2rF87eWF9H+ssNWAevTct17j56AHHOXUfWy1e\nuwMA4PFiuOwDWKZidnbd++pavvWGzuz65A4djSRLlfnQR7rTwBLJCxWWxd6ytrOunmvot/oHv9VY\n99Zp/Bvry7q+pHfpaFTaornma8Ayeh/60/NEDzjOifvYapHaHQAAjxlJ5kPkmh/gWEeFNgZzWab6\nh4+kPpGUqGeJ5GMlmh3ijMVBfy3LlfvtYvCcj3Wr7jF3RD5ITVnvLeld0sU2WKqpVtdjGq0BUaIH\nHOe0fWy1KO0OAIDHjSTzIbLZQY/l6ul2a9BWvjgksoG9tI/t3l7a/eLpa5bODm584ubF7BBqfl/m\nRJxPr9fT2rA5L9TX84a/s66sc03qP1xXA2ZLL1+PabgGDLai90w8ExDtdOA+tlqr2h0gyTr2mXr2\nMVfN0RxqGdqKezIfItfUBpJSf1rx12R2MGMdjbxvXR9az1dTVJSGbEmSuqX7gZjnsIblmmwebPrE\nCksavbewrqwT1X7zvhpgHY23lthc9LbuYfOpzac/AVrmoH1stTa1O0CSLNFzJZJSvdBbsdcG14la\nhvZ6UnHXyym+HHl7boJuz035H5ZJ89lh763rw10f8tFsWJela0O7kvJBvfXm0/7MlA+cXgtcIsd7\nQz+NvQqSpPf0P8uYrMr3F/pT+7eA37JWcw8ta8m6Wh96OvZxfQ2wVMVWelz+d9g6vCt632kuehGE\njdnxXpX0y9grcVFrfVM+WRS13bHnrfNb+q/Yq1DjDf2ype3ua8sTGal9p1Xl+mX9LPYqbGl3LXtV\nr7aqBFearmU3py/iJF9m33ypa+1jrmQebnm3kJLFAY7lmkgVV9S6/sxylQ+eyilmR1MfWSrNE0/O\npz/cFxtd+sFlvfNAeHcNyJVaLilTxzQfvtdkDXj17NEDjlPR7qpb3gW0O0ClpOkXF3l4iktALUNr\nPTlqlsydop9v+CTk9mxsTba8HyhTX7JMmVLl0uZE+LY4QFodMnVWz3azXFOfSMp8VPGln4ctkctn\nxWpGScuXv3X1FyGHyx5b1juWVlMDFofH1tOosqzD1uEY0Tu/oDHD+Vi+Vg+32p1PrHt4yzup3bHn\nrUNsjmTP9FxSoWfUr72I0JGarWXR+/ef0XYuFxP/HMQyGyzPhEsTJdZR4UPdabp8zPdIi6bY1VhS\nUZ5WYnEoZale6KW5uVYTU9CAavhE2eZsqJZXXj8O4oCyXpX0LjU1QJIstYGkzuw7mqwB544ecJzq\ndic9qOW1pt0BMz7U67rVW5WnlIEgqGVoK4bLHsQnmpTOpN8q09Snlin1oWXz57pNrDf/+9ALySc2\nn9XTOqs5EX2q1zcWvjklEDb19dy+XbpzK9VAt0192f6yLpX0LjU1QJJ8qn7pO5qtAWeNHnCc6nYn\nPajltandAZIkLziZgaZRy9BOXMk8ghc+9qml6iiz+9JZ89HsDPnigH451U9We35p+RQ3VPOJhrq3\njiRZYj0917NzXYnbUdaj+gEkbaoBPtFdrOgBx5m1O+lhLa9N7Q4AgMeNK5lH8+nmXUI+soFtPW7D\naieXsMFhd/k9bj6ysbp2r68o1cTPfh1us6yrS3qX2DXAx3arrt3r9TjRA451SsuL3e4AAHjMQieZ\nNxb3Me+fRv12ed+yrceFJ9o5Fb8lswFe2McL3a0mT4qvsqR3iV4DGo/eK5Hb/StRvx1n9ICWF73d\nAcDF+zRy/x77ESo4QeAk09+PvUGxbQ/AqnvovRfiQOdCHT7U7vprgH8Qew3weBza8q6/3QFA0/wH\nsdcAl4t7MgEAAAAAwZBkAgAAAACCYeKfOl+O8BDaG0u4VyiCGGW9Y01irwBwNq+1pt1x3w8AAAH9\nP5iF0LPVqhYDAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE1LTAxLTEzVDEzOjIxOjAzKzA5OjAwk/dd\ntgAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNS0wMS0xM1QxMzoyMTowMyswOTowMOKq5QoAAAAUdEVY\ndHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 6,
-       "text": [
-        "<IPython.core.display.Image at 0x7f47d05e8860>"
-       ]
-      }
-     ],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U2 = gate_sequence_product(q2.propagators())\n",
-      "\n",
-      "U2.tidyup()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.000 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.000 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.000 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.000 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.000 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.000\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.000 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.000 & 0.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 7,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  1.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  0.  1.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  1.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  1.  0.  0.]]"
-       ]
-      }
-     ],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U == U2"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 8,
-       "text": [
-        "True"
-       ]
-      }
-     ],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Versions"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%reload_ext version_information\n",
-      "\n",
-      "%version_information numpy, cython, scipy, matplotlib, qutip"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "html": [
-        "<table><tr><th>Software</th><th>Version</th></tr><tr><td>Python</td><td>3.4.0 64bit [GCC 4.8.2]</td></tr><tr><td>IPython</td><td>2.3.1</td></tr><tr><td>OS</td><td>Linux 3.16.0 29 generic x86_64 with Ubuntu 14.10 utopic</td></tr><tr><td>numpy</td><td>1.9.1</td></tr><tr><td>cython</td><td>0.21.2</td></tr><tr><td>scipy</td><td>0.14.1</td></tr><tr><td>matplotlib</td><td>1.4.2</td></tr><tr><td>qutip</td><td>3.1.0</td></tr><tr><td colspan='2'>Tue Jan 13 13:21:05 2015 JST</td></tr></table>"
-       ],
-       "json": [
-        "{\"Software versions\": [{\"version\": \"3.4.0 64bit [GCC 4.8.2]\", \"module\": \"Python\"}, {\"version\": \"2.3.1\", \"module\": \"IPython\"}, {\"version\": \"Linux 3.16.0 29 generic x86_64 with Ubuntu 14.10 utopic\", \"module\": \"OS\"}, {\"version\": \"1.9.1\", \"module\": \"numpy\"}, {\"version\": \"0.21.2\", \"module\": \"cython\"}, {\"version\": \"0.14.1\", \"module\": \"scipy\"}, {\"version\": \"1.4.2\", \"module\": \"matplotlib\"}, {\"version\": \"3.1.0\", \"module\": \"qutip\"}]}"
-       ],
-       "latex": [
-        "\\begin{tabular}{|l|l|}\\hline\n",
-        "{\\bf Software} & {\\bf Version} \\\\ \\hline\\hline\n",
-        "Python & 3.4.0 64bit [GCC 4.8.2] \\\\ \\hline\n",
-        "IPython & 2.3.1 \\\\ \\hline\n",
-        "OS & Linux 3.16.0 29 generic x86\\_64 with Ubuntu 14.10 utopic \\\\ \\hline\n",
-        "numpy & 1.9.1 \\\\ \\hline\n",
-        "cython & 0.21.2 \\\\ \\hline\n",
-        "scipy & 0.14.1 \\\\ \\hline\n",
-        "matplotlib & 1.4.2 \\\\ \\hline\n",
-        "qutip & 3.1.0 \\\\ \\hline\n",
-        "\\hline \\multicolumn{2}{|l|}{Tue Jan 13 13:21:05 2015 JST} \\\\ \\hline\n",
-        "\\end{tabular}\n"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 9,
-       "text": [
-        "Software versions\n",
-        "Python 3.4.0 64bit [GCC 4.8.2]\n",
-        "IPython 2.3.1\n",
-        "OS Linux 3.16.0 29 generic x86_64 with Ubuntu 14.10 utopic\n",
-        "numpy 1.9.1\n",
-        "cython 0.21.2\n",
-        "scipy 0.14.1\n",
-        "matplotlib 1.4.2\n",
-        "qutip 3.1.0\n",
-        "Tue Jan 13 13:21:05 2015 JST"
-       ]
-      }
-     ],
-     "prompt_number": 9
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "q.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[1. 0. 0. 0. 0. 0. 0. 0.]\n",
+       " [0. 1. 0. 0. 0. 0. 0. 0.]\n",
+       " [0. 0. 1. 0. 0. 0. 0. 0.]\n",
+       " [0. 0. 0. 1. 0. 0. 0. 0.]\n",
+       " [0. 0. 0. 0. 1. 0. 0. 0.]\n",
+       " [0. 0. 0. 0. 0. 0. 0. 1.]\n",
+       " [0. 0. 0. 0. 0. 0. 1. 0.]\n",
+       " [0. 0. 0. 0. 0. 1. 0. 0.]]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U = gate_sequence_product(q.propagators())\n",
+    "\n",
+    "U.tidyup()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q2 = q.resolve_gates()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABzIAAACSCAQAAACEEURXAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NOSF8os0JAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAG9tJREFUeNrt3V+oJOl53/HfEwYknFmNaiTWYy/hbGpWkfFFNpMaiC8UNoYeQu5km9oEDLlZ6Fnhu1y4GwK5ykUfg8mFL6xpAiE2AmuaOMFgjHOaJAuGkDDNRpFvxGqanYsNI1tsSdohRMTkzUVXd1efrq7+91a91ae/n2WZOXPOqXrref/VU3/eNidsYt/Qb+r7je/2Lfc3Qx/5+bE/0ev6NHQpJElv6bfc74YuBNAM+6E+DF2GHCMvAADe3ApdgFb7SN92/aZ3alehD/ssfUdjNw5dCEmygT4KXQagMR+6R6GLMMPICwCAP38tdAEAAAAAADcHSSYAAAAAwBvPj8vaO4r0KuDx3NMfuyzg/mWxm+7zXYuksCXGoarrerffuBn134J+/2fu49BRQDP273c3t+cBQL3sTX1NLwMW4LYy90HoKOAwvt/JfF/Si4DH845e6T/Us2mL1Mv/mmnsJqU/09OwciNd9fNtJbM3AF1mPRtysrOdReroPf0v/YkbNbCv4+u6TF7/0vy0t6n6rzl64fu99HHA/cOT7T3voH4XsOcBwEn7mn5DIZO8Cyno/nEE30nmi7DLp9igvvspLlPfnB66iUXqWdc9Xtt7qknVSYtFiiTJupIyu9LIDSUN1VPjywudGuupq5FM/0cdG+hxva3s+LouPYa8/nNP9VBSI/W/iN4Pa4pe+H4f8jorvNnW8w7pdyF7HgCcuJf6oPklMJeso07oEOBQvJO5B0uUuYnkMl2qa8naD3S3nGinGkoWK3ZDN9JQA0lymbKSbaHABkr00PX1of7QPda7Glha8x6Presy6fIejHXnf6u//gvR+4/NRA841Jaed0i/C9bzAAA4XySZ++hofoKTzk6EiizRZMvvJ24iKVLPIsmNFNns+sxYnPRXsI467t3l/Qs30bsaWHTMNrc6tq7LJPPtWKyplvdjaq3/INEDDlXR8w7sd4F6HgAA54wkcx/5KY51lGr9s906yxMgG9gze25X9syubJD/Wzw7uXETZy6TLFWWv5c5EdfTq3SvP9Tmphou3t2qx851Xaaq/mdbL96Pqbn+y6J3WXP0gENV9bzOtiSzVT0PkKX2qTl7zj1z1Il2hnby/U7mzdbR1AaS4tKPD4/mpzKWauT61nVD67nLxffTawtWFE/+ua9UJSl5RG6kJ7Xuc8e6LrOt/i3VeG179SmL3rjm6AGHqup5lf2udT0PZ88iPVEkKdZT3Q9dGtxUtDO01S17otjj9t7SCwVcAER/T4/sU29bu6u/WH5hiTR7+dmurOvWVzhM5kfuRpIlmlqs4rL5K4vo2yBf9memeOr0wK4CRnDpQp/or0IXQpL084uIvFWo37/vNU4rLXf3urbutf4zduPq+rdY07WlS4pfv+21DUtvNB29AHzH7JhIfD90EQ7whj4Jtu+3il9s6XlJoY/673mMvJu9oZ/os9CFqNDWfnd3cRkjtv/cqlq9K6kdY+bSa/pCwJFou7a2srrb2cqZcABf0T9uyR3a9raAKkFnlFvr62Yewwb6KNShSJL+m89VLq+tabV8V6iwVqF1NMk/b231Qa6ue2yd5SnM6ttElmriRhZLeeJZvJ7+Yem9szNmz+cRscG8fi1Rz73rcR+rLXfnunabPk5hc/13FFsqKVkezUr9f8fvSq2l0Yv1xGcrC97vPccMzbmW2JX0vPIxtoaex8gLzyxaJHKZ++XQpcFNVW87C76660f6dsjVbXEM3snc3fJkJdFkds3dUnXUW3+/zaL8Kvuya6ZafD6hdTR1I0nJ4t4mn9ZWZVKyGmp64BIgu9mjrstU1b8bur7ru74i118kRnXW/3i5nuZCN+h9R2CTtZ63T79rWc/D2XOZZpfxP5PXy/lA0aKdZbQztAtJ5k4ssYE6ivPVYCeKLFUmuZEuNc2vsYwKJzbzk/jCLf75g1oW66memTOn5cIUdSZMp69/fTVUS9becPVm77ouU1H/kmSxDSQbzPZRc/1fzlYzbiZ6wKHKe95e/a5dPQ+QG+qu/kD/1I2O3xawiRvqV/QHuk87Q7uw8M9O3ESTwjI9j5Ro6qaSJYrd0BI3kdzEllfbhy6T3NjyO5VWuO/mprp7bfOFu5xY56Z2qSt7vPgYglQDPd7/I9l33Nu+dV2mov5nR6R+YR+11r+b2qWe2bvNRA84VHnP26vftarnAZLkMnuhV6FLgRvvlV4wr6NtSDIP4DLN32xLJetqlJ/IjKyTfyhJ3tUXj8MmlU+Ux47r6ZXc0KZ6alNd6G0bKNOj4iJKte55a11v+K3Zn62ofze0SZjoAYea9bz9+l3beh4AAOeLJPMIbrr6CYRuZD2brF9Lqv7gexuIV5q3cmPdt0SX+lD/OkSKtGtdlwlf/26i+xZrGCp6wGGO6Xdt6HkAAJwr3sn0yl2WfiBMtPkNOItmD3hhOzfRM/2ntiRJG+q6TCvq303bFD3gMHv0u5b0PAAAzhF3Mj0re/yq6sTeZaxveKp2fdSO+gf82f0RV3oeAAChcCcTAAAAAOANSSYAAAAAwBsel63ys/pVS47fzJ6+HPqwz9JX9A+2fjxCMy703dBFABrzC3YVugg5Rl4AALwhyazgvqVvhS4DmuF+LXQJgHPk/kboEgAAAP94XBYAAAAA4A1JJgAAAADAG5JMAAAAAIA3JJkAAAAAAG9IMgEAAAAA3pBkAgAAAAC8IckEAAAAAHhDkgkAAAAA8IYkEwAAAADgDUkmAAAAAMAbkkwAAAAAgDckmQAAAAAAb0gyAQAAAADekGQCAAAAALwhyQQAAAAAeEOSCQAAAADwhiQTAAAAAOANSSYAAAAAwBuSTAAAAACANySZAAAAAABvSDIBAAAAAN6QZAIAAAAAvCHJBAAAAAB4Q5IJAAAAAPCGJBMAAAAA4A1JJgAAAADAG5JMAAAAAIA3JJkAAAAAAG9IMgEAAAAA3pBkAgAAAAC8IckEAAAAAHhDkgkAAAAA8IYkEwAAAADgDUkmAAAAAMAbkkwAAAAAgDckmQAAAAAAb0gyAQAAAADe3ApdAABoE/s76ulF47t92/0jj8fwpr6ml7WU857+zH3cTEhOmf26ftD4Tk+wbuwdRXoVuhSSiN6ubitzH4Q+8v3UOB7u6wSjd9PYv9NHje/0Qt/0We/2jZqOwXv7JMkEgKIvSxo3vtdHXrf2Nf2G6jmVeUev6XebCMiJ++f6o8b3+Y6kj0Mf+J7elwJc0ilD9HZzIdU0ttSnvvFwX6cYvZvmjQAz2HuKvG7vN/XtWsrpvX2SZALAqheu8STTPvW6uZf6wPVrKecgwFXgU/RJPfGvYoOW3K3ZxwuNm+9tZYjebqyjTujD3ltt4+G+TjJ6N81nAeb3jucnDr5f0/zuvX3yTiYAAAAAwBuSTAA4msX7fM8i8/vwDAAAqEHV/L7+Xeb3pdYkmVQhcH726/cher5FNsj/61my8ad6yio20l1sK38UxWXqtm8Ma0O8zxkXKnZTPWrs9htEb9fvnmuk9m9lRG/t6E+gre0yw2+Z3/MZ/vTm9yYiXvM7mSvP947cJP+XtbcIrKdh5Ya66s+36MaSy6xnQ1dd7QCC8N3vLVIy+93me77L1Denh25ikXrWdY9LjjfVZHOZLJq98m9dSZldaeSGkobqqaG3hCxSL/9rprGbbPipktpgpPVjlxrY0hu6y9ZisZs2VzfWUUe/rh/qTzV009bHqVzY6L2vX7F/fyLRCxQpi9XVP9SX9a363zKtrZWFjd7Xdc/UxDu66/N7+Qx/CvP7LjN89fw+n+FPcX5vIuI1J5lubBN9qrsuk6xnA73rxrPGuHLwO1WhZKmkzHrK3LDJKgSwD8/9PtjgnZcjUeYmksvsUp/asGQQ77qqtWFTDSWLFbu+ZNITDSWXWWbJpgnBr6MSZUZaD449kZn3hdxTPZTUQN1YpCeKNNTnNNHP6MpG9S6fcvwJXyuj929OJXrBIjVQqkv9thJN1LOuHtd52ltPKwsevX/ZTPRK5/dsfYY/lfl9hxm+en6XUg1Pdn6vPeK1Py7rstn/krtUNH9s7JrulmsvaZ6BJ27kxu5SieQyZZsfXgMQkr9+b7FiN3QjDTXIt9x0z19OnelsMlpliaqnktlUE6lnkeRGmj9UM1ba1CEsp1Fdqlsavw21wUjrx9YaqO4N6fIqtC16UwN181QT98iN9FO9dEM9VGSDVsepHNGb2/Vcq9FI2UCRHrqhXuqnbuQeaaKnLY/TWUfvhs3vW2b4rfP7bIY/0fm9/og3+05mVvZJMTtWoSSlK6FosAoBHOy4fh908J6VQ/MHgtLST7PszI/EBvbMntuVPbOr+emkxbO3OdzEmcskS5XljwZN1NxkekyizEjrw3EnMotr4hZrWng/qNa6sZ4yd7n82mXqKz3kXbXG4lSuTdGrt8/7OF1uOFIWK1W/eJfFXSqz3uFbbCBO5c4leqtOfX7fNsNXzu/zGf6E5/eaI95gkmmJkvw6T2Spdexp/sLpTlUoSRrpmQ1sMNtKo1UI4CDH9vvAg/espJENbKCue1T6+Es0K6mlGrmHunSPNHKPFg/GpdfehCi8teP545mrHJEoM9J6ccSJTGEO1PztpZma6ybVtQevZlfK2xCncq2PXr/mE2gPp8uNR6qry7UH+R63I07lzj56xVgs5/fVGb4QwxZffJ2pnuGr5/frM/zJze91R/yWJV4DcaHb6/9oA0mZpPvzzuBGkvWUaKzVKuxb1w2tV7z+V6jC2Y35qUb51+slv6MHVl+09nHvBD/Yuf1H8Iv63y2p33JfafUH1dcXvXr7/UzV4O233z/QncJRJNJsQrEr67qyhQxmxzM7ukRTi1Vc4CMuLvdhg/zNk5niycFr5vNDkFeOQVJHUxtIije8XVJdG8V4f641Y+zSPb3y/FHXx7t77evqGqiO/6IvWKrx2m8u+Z7/7inJt3ex2PJf6J+Zz6VFro8dO8WpXMui93pJ9P6vvh4+etvH3MpI3daF17Hq6+rn23tQ2PLrAcfDQ1pZu6L3c7VGb3aUa/P7ygy/iOG2Xpmrmt99x+y1lePYNsNXz+8rM3zF/O57dFk5hiPn9zrbp26p4zXJfLPsZHNtvavVDrxjFVqkgXtsffV0ZbNmvT4Q3NMX9SWfATrQ5/Smvhe6EEf6qj7WT0MX4pr7kn4mdCEqvK3vhC5ChfqiV2O/n6kYvCXpi/q7Hvv9hT5f+Gr5IMpiWQdLlLmpZJHLpJWr3l332DrL8q0+pmKpJm5ksZQfW3Hs/YJ8Du0XxS+OTpSL8f6i7rVijF092h/px6ELcc1Kknnkicx8Dow1XbtrsVo3PvuBdHvRJt+UFlt+3WtLXRk7do2TZF2tPrY7dmOi5+d0eUukbutNr8fwun4p/9tFYcu3A46HyTJJLGlnpxC9v15f9AqRuJ5KF496EcMjL77WEbPVC4BrM/zu8/vqDF85v/seXb6wUobj5vc626durWSzR7PBAXe/dq3CVON8HaVocS/kuu81sYAzQmlmge6bqr7o1drvtWXwlqQXPo9sZYH2xYMokhL1JUsUKdMTPbKutHo11qL8hKT4hsRlYbtTN5GUuPmzGMXJ9BOfK09eO4ayRDlS4sbWydecq6yNlXj/gD64i2vv3pXVQEeT+fIZO16o6Ci2VFJig0UtFOvGaz+QLJ23yeX+rKPIa0tdHTtK4rQSqUWc3KYPRyB6O0RP1WNudaRe6gOvxxAVotNZxCxtdjzcFKcN7azt0evWGL3drD52evjF1zpitjo2X5/hv6H/vvP8Xpjht8zvvkeX4jEcO7/X2D6bXvhni0IVLqVaVli0+Ns0/xPAidvS72eD90hSsrj22VDPt8QG6ijOHx+ZKLJUmSaKNdHyWu1oUfJu/i+FCWB+TdtiPdUzc+a0fCulkQXOtTqNTiRLLFKqiT2TdG2JiNLaYKQ91noNpOqop7UFOkriv+gLbuj6ru/6ilx/ccJSZ92MSxYQ6dbaatfiJG2KVBmit1v0qsfchiM1WX/L13qq80KW/1bWtuiNDtlUXap6Zcj5fcMM/1/3md/nM/xJz++1RrzmJNM6NpCULp/xtY4SJdaxruL833eqQsmNZteHLNXETRutQgB78NnvQw7ebuL67q57nJ8qPFKmiZu6LJ9+8gd+3GTxQNXQXUpuPF/ww9LCnZepu+vMmTN3P/+ntIlTgQ2JstxQscZunF+1rKgNRtrjlNeAG+lS08U1450uVEiSxTaQbDDbWs1107++HL51K+4h1hInaSVSoy33VNoevagl0ascc5uNlBsqspVEyZKVN/RCxqlcu6Kn1YsZdUYv38Pa/F4ywxdj2NaLr+Uz/P/YdX4vzvCnO7/XHnHn9T8N1Dngt57mf0b5n/HiO6nSlZ9M1Jl/Vz0lfvbPf6fyH/XbzujV3e+v/d5az/d7ZOposOUnuuqpqyeF8pbuv3o7y993ctKV1xrZcAyKZiOoIkXqKXWax7KiNlbiTR/csQY21OeiBpJi9DfHf5++4L9u1NFz9WZbVqSBns3L520PG8o8j9P1SM3jtCm6LY9e7HkPB0bvmDF3+/i491FEeqaBotmW1dPzGmqicjw8rpWda/S2/NYihsf0yjpitm2u3XV+r57hr83vnkeX8mM4ZH6vu32243HZ0SwLX9yzXL6Suny6efadiRsvvhs7rq8Dp2vnfn9NC3q+u1S8fKDLjZTY2hviVrmkmg3qvdq8odxZPoJ21VOk2DqLBQA210YL4n1zzGrAYqVK7KpwPXlT/IP2BTfWQ8X2XO/rm3omuYdrS5rUGqf8cwCLkRpVrX3Y0ui9p9/Jozc9fqs+oteuMddl7qGkZ/qm3rfnivWwqbe+PbWydkTvd/Res9HbYhHDdvXKXewyv1fP8Cc0v9cc8VvNh6EkMCPr2WR98mpfFQLw5ZB+34aeb5Fi6+bvkcyP5bLk444jDSu2MWzqdL3M+oJvG2sjeLxvIje9HtXy+IfvCy7T4+LSNU27HqlN7bQ0Pi2JXji7Rq8FkeqrX1y6plnHtLK2RK/ufexdpta2tWo7z+8VM/zpzO/1R7wddzJn1w3WtbYKARxv337fjp7vMtd3w+vvVq1fC3TTzfctXNbUPY09jqukNtoQ73NR2hta3hdC2DBqlCF6a05zzG3eHq2M6G1wmm1t1/m9aoY/lfm9iYi34k6mtKkKN/50xnqHwOnbr9/T8+tVkigT7waVXaio+OmzrZtdH+4ieqVHzpi7k90fISR6G4+ettYipbVRe8RbcicTAAAAAHATtOZOJgDAk9u6sP0/QHsXF7od+uBOwms1xb/KKdbNHT2w0GWYIXq7eaA7oQ97b/WNh/s6xeihfe7W1J69t0+STAAo+iv96urn2zXiF7xuLdPnVc8k9Hn9vybCcfI+qSn+VT5/gg+b/aVifSl0ISQRvV3d0V+GPuy91Tce7usUo3fTvGFXje/zQt/1ur2f1NSevbdPkkwAKHD/RX8rdBmOPoYP9EHoMpw392uhS3Aa3L8IXYJTRvR2w3iIJfeLoUvg4Rh+OXQJdsU7mQAAAAAAb0gyAQAAAADekGQCAAAAALwhyQQAAAAAeEOSCQAAAADwhiQTAAAAAOANSSYAAAAAwBuSTAAAAACANySZAAAAAABvSDIBAAAAAN6QZAIAAAAAvCHJBAAAAAB4Q5IJAAAAAPCGJBMAAAAA4A1JJgAAAADAG5JMAAAAAIA3JJkAAAAAAG9IMgEAAAAA3pBkAgAAAAC8IckEAAAAAHhDkgkAAAAA8IYkEwAAAADgDUkmAAAAAMAbkkwAAAAAgDckmQAAAAAAb0gyAQAAAADekGQCAAAAALwhyQQAAAAAeEOSCQAAAADwhiQTAAAAAOANSSYAAAAAwBuSTAAAAACANySZAAAAAABvSDIBAAAAAN6QZAIAAAAAvCHJBAAAAAB4Q5IJAAAAAPDmVugCoF72+/qk8Z1e6Jvug9BHDgAAACAEksyb7iv6t43v8z1FoQ8bAAAAQBgkmTfdZ27c9C6to1ehDxsAAABAGLyTCQAAAADwhiQTayze53sWGQ/HAgAAAMjxuOxZsUi9/K+Zxm5S+jM9DSs20VV/8ZOxm0ous54NXRb62AAAAAC0AXcyz4rLXF89jVxfQ6X2ZP0nLNVkc8Jo0cqSPk/zP4eL1BUAAADAmSPJPDOWKHMTyWW6VNeStR/oVi4UlC7vclp3/jeXKSvZEgAAAIAzRJJ5bjqaJ5HpLN0sskSTyt9O5r9hsaZa3vEcKw19YAAAAADagCTz3ORppHWU6tHadzvzJNMG9sye25U9sysb5P8WF9LKpHjH001U+51MS+1T9fR73DM9BNEDcAjGDjTBUv2hevacdgbcHCz8c246mtpAUuwelXw3mqWRlmrk+tZ1Q+u5y8V3Fw/LWqrx2m/WyiI9USTp5/RU94NF70QRPQCHYOxAEyzSE70mKaadATfHLet5TQ/e0Z8HPZ6v6sI6QUsw8zm9qe+FLoQk6a3iF5ZIri9JdmVdt76KbDJLHt1IskRTizUtfDd2U2n2qOza4kDFry/0nvdauFi009j+lX7afCB38ra+E7oIpeqOXuh+X0eLO0xbW0C1v63/GboIR7nQj/Tj0IXw5qv6uEUjHCPv8drYPn9W0g9CF6LgFNpZu1vZHX1RL2rZ8kXgI7und+bP0wXW7hawSdAZ5ZbGXpPMC70KdSiSpJea6sOgJZi7p5ehiyBJ1x6JXb6RuVgn1jqaLQQkaeWNzK57bJ1l8lh4X7Oj2FJJiQ00zh+bLbaiH9VQC7f1T/K//UR/HCqYW73QR6GLUKru6IXu93W0uMO0tQVU+26rTjf3d0+vArdAn/68JXPHDCPv8drYPm9LrSrTsp191tp21u5Wdlu3axo5Hig+fiNHeKWPNT5+Mx60uwVsEnRGueUmx29kyTqBh60f60PXjsbYEvbpypfLRDFRX7JEsRJ1pOWnX+a/F+XDSnGhoPzB2fkdUOu55W8V72TWUgv2WE8kZXrc4hpubcnqjR79fqEdpQC8YeRFE06gnbW1XDUz6UtBC/BKL1rSJtpRipPCwj9nwxIbqKM4f6xwoshSZW6kS00XyeJI84cOu3l3KryEX3xE1mIbSDaYbc1ieb1YUcYNdVePdN+NQkfyFBE9AIdg7EATaGfAzcPCP2fDTTQp3K98pERTN7VEsRta/tEkbmK9/PtDl0lubPk7mZauppFuqn5ha6kamBhcxnWkwxE9AIdg7EATaGfATcOdzDPlMjd2U4uVKrGrwv3K0eze5PyupZsv/JNUXl+M/T52DQAAAOBU+b6TeUcPLOTxhF4F68S46fV3Md3Ieja5vnasVS4OZYPrW8GZCd/vb4cOAQAAN87twJ/a8EB3QocAh/KdZE4VB35F+IdB934DuMvCOrJzkYabft6i2aO1OGPh+z0tEAAA3zJJIZPMOysfpYeTYi50CVAru3KPjt/KnvtcfrAJAAAAgDPDO5kAAAAAAG9IMgEAAAAA3vARJjfdawFe2GYZFgAAAOBs/X8dEm4J71ZbhAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOS0wNS0yOVQxMzo1NzozMyswMDowMO/2KVEAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTktMDUtMjlUMTM6NTc6MzMrMDA6MDCeq5HtAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q2.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.000 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.000 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.000 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.000 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.000 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.000\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.000 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.000 & 0.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  1.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  0.  0.  0.  0.  1.]\n",
+       " [ 0.  0.  0.  0.  0.  0.  1.  0.]\n",
+       " [ 0.  0.  0.  0.  0.  1.  0.  0.]]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U2 = gate_sequence_product(q2.propagators())\n",
+    "\n",
+    "U2.tidyup()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U == U2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Versions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": {
+       "Software versions": [
+        {
+         "module": "Python",
+         "version": "3.4.0 64bit [GCC 4.8.2]"
+        },
+        {
+         "module": "IPython",
+         "version": "2.3.1"
+        },
+        {
+         "module": "OS",
+         "version": "Linux 3.16.0 29 generic x86_64 with Ubuntu 14.10 utopic"
+        },
+        {
+         "module": "numpy",
+         "version": "1.9.1"
+        },
+        {
+         "module": "cython",
+         "version": "0.21.2"
+        },
+        {
+         "module": "scipy",
+         "version": "0.14.1"
+        },
+        {
+         "module": "matplotlib",
+         "version": "1.4.2"
+        },
+        {
+         "module": "qutip",
+         "version": "3.1.0"
+        }
+       ]
+      },
+      "text/html": [
+       "<table><tr><th>Software</th><th>Version</th></tr><tr><td>Python</td><td>3.4.0 64bit [GCC 4.8.2]</td></tr><tr><td>IPython</td><td>2.3.1</td></tr><tr><td>OS</td><td>Linux 3.16.0 29 generic x86_64 with Ubuntu 14.10 utopic</td></tr><tr><td>numpy</td><td>1.9.1</td></tr><tr><td>cython</td><td>0.21.2</td></tr><tr><td>scipy</td><td>0.14.1</td></tr><tr><td>matplotlib</td><td>1.4.2</td></tr><tr><td>qutip</td><td>3.1.0</td></tr><tr><td colspan='2'>Tue Jan 13 13:21:05 2015 JST</td></tr></table>"
+      ],
+      "text/latex": [
+       "\\begin{tabular}{|l|l|}\\hline\n",
+       "{\\bf Software} & {\\bf Version} \\\\ \\hline\\hline\n",
+       "Python & 3.4.0 64bit [GCC 4.8.2] \\\\ \\hline\n",
+       "IPython & 2.3.1 \\\\ \\hline\n",
+       "OS & Linux 3.16.0 29 generic x86\\_64 with Ubuntu 14.10 utopic \\\\ \\hline\n",
+       "numpy & 1.9.1 \\\\ \\hline\n",
+       "cython & 0.21.2 \\\\ \\hline\n",
+       "scipy & 0.14.1 \\\\ \\hline\n",
+       "matplotlib & 1.4.2 \\\\ \\hline\n",
+       "qutip & 3.1.0 \\\\ \\hline\n",
+       "\\hline \\multicolumn{2}{|l|}{Tue Jan 13 13:21:05 2015 JST} \\\\ \\hline\n",
+       "\\end{tabular}\n"
+      ],
+      "text/plain": [
+       "Software versions\n",
+       "Python 3.4.0 64bit [GCC 4.8.2]\n",
+       "IPython 2.3.1\n",
+       "OS Linux 3.16.0 29 generic x86_64 with Ubuntu 14.10 utopic\n",
+       "numpy 1.9.1\n",
+       "cython 0.21.2\n",
+       "scipy 0.14.1\n",
+       "matplotlib 1.4.2\n",
+       "qutip 3.1.0\n",
+       "Tue Jan 13 13:21:05 2015 JST"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%reload_ext version_information\n",
+    "\n",
+    "%version_information numpy, cython, scipy, matplotlib, qutip"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/examples/quantum-gates.ipynb
+++ b/examples/quantum-gates.ipynb
@@ -1,2047 +1,1813 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:bd051ae1993b5ec00c8deb487280efe218018428f03031a3bc2ed79488709707"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "QuTiP example: Quantum Gates and their usage\n"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Author: Anubhav Vardhan (anubhavvardhan@gmail.com)\n",
-      "\n",
-      "For more information about QuTiP see [http://qutip.org](http://qutip.org)"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%matplotlib inline"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from IPython.display import Image"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from numpy import pi"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from qutip import *"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Introduction"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "http://en.wikipedia.org/wiki/Quantum_gate\n"
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Gates in QuTiP and their representation"
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Controlled-PHASE"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "cphase(pi/2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0j\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 5,
-       "text": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 1.+0.j  0.+0.j  0.+0.j  0.+0.j]\n",
-        " [ 0.+0.j  1.+0.j  0.+0.j  0.+0.j]\n",
-        " [ 0.+0.j  0.+0.j  1.+0.j  0.+0.j]\n",
-        " [ 0.+0.j  0.+0.j  0.+0.j  0.+1.j]]"
-       ]
-      }
-     ],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/cphase.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIMAAABBCAQAAABYtN9SAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAC1UlEQVR42u2bQW6cQBBFX0XeR+1NliMR5QRz\nBQ6QDVcgRxhLuQA5QRSUfSRzhHCEoJwgSL6AkaXsKwuK8TD2IE3STFtRfRYDzXRTvO6qrkYgSjpJ\n4BcBgF7fJjSEK6kSXn1jECCTzzwks6OVxKPh3nYHvU5oCK9SXlwHPowQ7DeZko4GAHnPO77qkNaK\npKMBgN/8TA3hJWB4EXIMgGMwOQbAMZgcA+AYTI4BcAwmxwA4BpNjAByDyTEAjsHkGADHYHIMgGMw\nOQbAMZgcA+AYTI4BcAwmxwA4BpNjAByDyTEAjsHkGADHYHIMgGMwOQYg+ptw8o27M6ts4C/qfNQ+\npt1XUSnAnd6cV0ECnPsmnFRxIcTHcLbSvwwIHhtMSTBItnROwlFJOC6Jr9WcQnJy2+1pD31ZKj4t\nVCzH6CKBrbYAOshO6nWdZzUM2krHPdc6SKCSYQqdUtCevqWp36UgMMh3Gq2Bmh1nht5zzY26Uc2O\n1H4DSmn7t4v1S7YK2dgOOfcERWHH9tRVYmwXiQ2PvS9blqe6TDsgsJMA2hLYAtBSrGnhRSZMqai1\nBiCn25flBHoCA53Fg4wBQDsEQAoGiw/dul8BrYxBKiCATp+NhPFGpaDRGym1lp0+BsyCZla9PIgI\nq84WV5L/eyMHejM/tF7+ItU8u9RmdBDJZk4SZjPKzgLkqMOw+jqy1f1l8obBPHyuUlsyTsQNKei1\nlmyfY6w7Gkbfi6WTvZSDZLO+DmR2ZrKgeMwnJKfXDthq80xrD3GtXjGLlFwqkEpyoGawdKrZJ1Ul\nLUfjZJpRJOOWH6KiVPuSyDd+pDXzhoPyQE52mDeM+YAylioUFAvt/g95A+igU0LdjI4z9fzeUZ4f\n/pPGfGI1XXxppQ3506XS8uJJqpVT6RQrTL3h6QozUJ/6vwRWXlgleuzydIAvPU3SgdUfzfhjF8Ax\nmGI7xSZymnvqKiFutPgDnP6w1tVDAg0AAAAldEVYdGRhdGU6Y3JlYXRlADIwMTQtMDYtMjNUMTU6\nMDQ6MDUrMDk6MDDgC3HbAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE0LTA2LTIzVDE1OjA0OjA1KzA5\nOjAwkVbJZwAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNSAFXAs5AAAAAElFTkSuQmCC\n",
-       "prompt_number": 6,
-       "text": [
-        "<IPython.core.display.Image at 0x7f331d02dc88>"
-       ]
-      }
-     ],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Rotation about X-axis"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rx(pi/2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}0.707 & -0.707j\\\\-0.707j & 0.707\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 7,
-       "text": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 0.70710678+0.j          0.00000000-0.70710678j]\n",
-        " [ 0.00000000-0.70710678j  0.70710678+0.j        ]]"
-       ]
-      }
-     ],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/rx.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIoAAAAWCAQAAAC1KszXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAACPklEQVRYw+2XzZGcMBCFv3bt3aWTj67SwQlo\nA/BBDoEUcAgQAk6BEJYQViEsKUyVE1g5g/YBwTAMy7rKaHamapoLCKmlfuqf1yh7PjT76vuYXT9x\nlzO5g7IiVwCK2O2/YhYjZjmytzxkNddQpddI0H51TsOvTSWl1kmX0wCgUSppNd4oKBqpRXnUHqSR\nUn+eQVIQtswbfUIKDFGe6bQFWirqnAfPWgdwvE7vij+b//SOvhKnYAe9eF4xikKFu93q4wnTXUcW\nASSOwzvrrfaAoRIDGjA4AAJFvkNnDR/ADUCIp+LHWaD4ESZp8BgOGCK9ptAQSwTQHhmBTXmll+Z2\nQfEcpAGsPq78NYPRUtBpLaW2Uuk87RZ0J/PLWSbJWIEexO+q78v8Qxyk2vEspbZvLdJuCCWxi3Ay\nOvuWKqXZQSavE8PXXa2IeXPKlFEw2MEA8SB+hZuUGrDMAuw040jBQVux08qcnqLh/5XMjn56Y25K\nrY4a5Dvf6OSFmoqT8iwJtBmMUBwZjHgO2gNOu+WeGuX3vlZk8xRx0uCxCaYeIwV/tMUSNCTG0jGC\nWBKAmGrLZG7SZXniRVSUZhrZFYaFXKZfxeCxGAwVhTKyjJGnDOxDwU4rCoqNfbLylNzV53jnAaTC\nAFamUkwnXsPRJ2aJ1ekWZ7XrTcM+ciFQkslnXY520kh/TvS3Wz5pspL8j++StWatSza8WcDFkLUd\nvLCnrMtaIOgG/ddIVkiuwFOuUe6grMje4bMv4f5X+byvur/UQi6vE0IEeQAAACV0RVh0ZGF0ZTpj\ncmVhdGUAMjAxNC0wNi0yM1QxNToxMjo1NCswOTowMMIM24wAAAAldEVYdGRhdGU6bW9kaWZ5ADIw\nMTQtMDYtMjNUMTU6MTI6NTQrMDk6MDCzUWMwAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVc\nCzkAAAAASUVORK5CYII=\n",
-       "prompt_number": 8,
-       "text": [
-        "<IPython.core.display.Image at 0x7f331800fbe0>"
-       ]
-      }
-     ],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Rotation about Y-axis"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "ry(pi/2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}0.707 & -0.707\\\\0.707 & 0.707\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 9,
-       "text": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 0.70710678 -0.70710678]\n",
-        " [ 0.70710678  0.70710678]]"
-       ]
-      }
-     ],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/ry.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIoAAAAYCAQAAACPIK2nAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAACXElEQVRYw+2YzW3cMBCFvwm2AVZggA3kQF9y\nyoUpQS3ISAXaEuQSohKsElYXn3yJWhDgBswSJgf9WCtphSSmhF3AT4cVKXKkeeQ8zqwon5jiENec\nvPC8uw/f9Vtcg5FJ4VmPu5HRQfLYFr/s7cIt4JOUBVwBKWLXnomZ9JhpT3zE1pSJA2TdbaDSenFM\nzuOKibTVKDE4rQA0SCaFhpslRQNHUe61Bskl1YcZJQnVZQf7PSEJhiAnSi2Agoxt5VyjXuSTtuNt\nuFf8bPzTqrUUp2Bbq3jeMIpChrv8zo9fW2uKpxpWOzAJIHE0q7Ot1oAhEwNaYXAAVCRbfvSm4QO4\nlgjxZPyYBYrvaZIcj6HBEKg7HbEEAK2RntZOV+r4ucmepHgayQGr9wtPTeu2JJR6lFQLyfRddhPK\ns9HpSEk2PYEOkTn/Om6Ig27VT5JqcWmSlm0oiT0LJ6OjlmSdzLYY77m7uD7o8RA3LZ983qAoGGxH\nU9AGxOpUTVJ9EP/u7LneSEKjpVjo5o13ymvs0mJboXWDtDoqkJ/AL5AUPyGzI23UPwoe8TRaAk4b\ndsBmpIiTHI+V1s0aIwkvWOqeIqAcSEipgNCdLgD0siyWJ36LipIPPdVffcT/Yts8Zeg3eKxCjlc4\nTfOUNv9QsN1vQrLylhvPU4ZV10oboMFJOlKLst1J/a4YwsNpuWLOLpcMsbB7QaiPjDa/lvh5gbde\n8km+cZK/LylisO05MiLpyLxKNhQrNjYuB7dP3s6gYWmN56GwdsZoYGNKruL/lOvDJykLiB0+d+I/\nbuRf3xnb4B/TNrOzyMTS2wAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxNC0wNi0yM1QxNToxNToyNysw\nOTowMBv903EAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTQtMDYtMjNUMTU6MTU6MjcrMDk6MDBqoGvN\nAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
-       "prompt_number": 10,
-       "text": [
-        "<IPython.core.display.Image at 0x7f331800fcc0>"
-       ]
-      }
-     ],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Rotation about Z-axis"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "rz(pi/2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.707-0.707j) & 0.0\\\\0.0 & (0.707+0.707j)\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 11,
-       "text": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 0.70710678-0.70710678j  0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j          0.70710678+0.70710678j]]"
-       ]
-      }
-     ],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/rz.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIoAAAAWCAQAAAC1KszXAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAACMUlEQVRYw+2XwXGkMBBFX285AZ183CqlIIeg\nDUEpsCFACDgFQjAhDCEsKXDfiwmhfUDAwDB4q4w8O1Xz5zAgoCV9df/uRjnyR3msvdvM+YMHLvAg\nZQM3J0Xs/lMxqxGzHjkeT0k3bMjjZU+j7cYbJa+7JjItoiWnDYD2kkul/d2Soj2FKC/agpSS6e8V\nJYFmb3ujT0jA0MuJWiugIqdIue7EmQDH+3St+NXTt0+sZTgFO1jF845RFHLcPWcfTzOdds8igMTR\nffK11RYw5GJAGwwOgIaQctFJwwdwAxHiyfm1ChU/kyQlHkOHoaeNOmLpAbRFRlqjrrRS3jMpnk5K\nwOrLxTNDJEkCtRaSaSW5zsIbqBfvZ2dKkjQDPYk/1N7z+Y04iKd+kkyrax9pPQST2EVAGT27kzzK\n7IBzn3s+dg/apNWUSVEwxHpE/JVKI9MGO292qTgS6LQSO1U1aT1Fm68bOVv88szcpBqOAsThsHhY\np1QZSZtpDHMFI55OW8BpvTHp32P3kLCiFSclHhtpajES6LXilW4IKWpmCjMaoI/ZBYBRlsXyxh9R\nUcpp5GAaVviejhWDxyo4gjJWGXOdMtQfCjb+B8LOLHdep0ynro12Ygk4OU3+UI/hNnrFJK3bgTLC\nbrUMxyF1Sl5S0y21RGsppb0s9PdbPikTF/m37pK1YKtLNlxN32JI3A5+s6dsYSsQdKf8157ElNzc\nU/5PPEjZwNHh8/PgtuFf8Px1E0t8ALIfLa6j45wgAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE0LTA2\nLTIzVDE1OjE1OjUxKzA5OjAwcujvUgAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNC0wNi0yM1QxNTox\nNTo1MSswOTowMAO1V+4AAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAAAABJRU5ErkJg\ngg==\n",
-       "prompt_number": 12,
-       "text": [
-        "<IPython.core.display.Image at 0x7f331800f898>"
-       ]
-      }
-     ],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "CNOT"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": true,
-     "input": [
-      "cnot()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 13,
-       "text": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.]\n",
-        " [ 0.  1.  0.  0.]\n",
-        " [ 0.  0.  0.  1.]\n",
-        " [ 0.  0.  1.  0.]]"
-       ]
-      }
-     ],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/cnot.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAAA2CAQAAADtl0aoAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAABT0lEQVRo3u2asU0DQRBF3yAnhEsDlhZRgVvY\nAkhMRkJwVwIuwR0gIzKIjszpugQQFXASDWAhIREuAWtAdjojbTD/ghttMPP09XUT3EpBXxJ4JQAw\nllP9/hNZGlBPKzJEueFD3RQjp99ruS0n+v2PDJgpW/of5PrWNsXCaQA554y7srXobeI0AJ+82CBb\nQhvKoR3aoRuQQzu0Qzcgh3Zoh25ADu3QDt2AHNqhHboBObRDO3QDcmiHdugGNLFoKoHEFSKBjcXP\nIgOnZU4msuaBSJa5gStF+aFjRSiQSAUCK5bqM5TbRXKtEqlWmZnuFO14dNwenPV0ukO0oWN53D8q\n4++dBCUJulcnLrmv1RR4q/UFg+oU5UwPhP1MF3Y5bzXTz4f5lY6N8hT1z1Em/neawNPO/VadhgXD\n30KRRKbX3ooGl1QkcM2ML+CYkYX+Iv8GxveJso3/mFgAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTQt\nMDYtMjNUMTU6MTc6NTkrMDk6MDBF8nEIAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE0LTA2LTIzVDE1\nOjE3OjU5KzA5OjAwNK/JtAAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNSAFXAs5AAAAAElFTkSu\nQmCC\n",
-       "prompt_number": 14,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317f9f278>"
-       ]
-      }
-     ],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "CSIGN"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "csign()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 0.0 & 0.0 & -1.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 15,
-       "text": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.]\n",
-        " [ 0.  1.  0.  0.]\n",
-        " [ 0.  0.  1.  0.]\n",
-        " [ 0.  0.  0. -1.]]"
-       ]
-      }
-     ],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/csign.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAGAAAAA9CAQAAAD4gaSaAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAABe0lEQVRo3u2awW3CQBBF30bcI+eSoyWnBFqg\nhURKA1AClOBUEEEDObgFLpxyCSVgiQawUsHkgBVCFIlD9mdiaZ4P2Mja77c72JYYDNXGPQeMHWNd\nhpEMDalgRwFAa3eiEGCUatHIZX/5UKVn3kUprXIFDv1uZzeiEOBKNbB1zI6X33/KgoQbBS8UygTT\nrUC/CnvrpPOvFfgLQsCbEPAmBLwJAW9CwJsQ8CYEvAkBb0LAmxDwJgS8CQFvQsCbEPAmBLwJAW9C\nwJvBC2T+nzi9sjn7omT/7ZTSHnMmjjJPyMYWFxQzdwYMvoQGL5C7hL5wVixbawYnwJSZNZAq3nhQ\nhShLaNXPes3a1qoQ5Qo0AOmeCdKGp0nW8W5Pu7aFVLBkcWr4SAVl1sROfReas7WVNCFzh1B9djTB\nqI4NgD+f8c/7hVjyZC0AY1WEUCDVdMcXi1TpUmR3oVQxp+kfZlNkvwOZgLWkz4PFLwa6wODfhQYv\nkLuELj+mrvMGfgCn7laLwE5jfwAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxNC0wNi0yM1QxNToyMzo1\nOSswOTowMNX7t3MAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTQtMDYtMjNUMTU6MjM6NTkrMDk6MDCk\npg/PAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
-       "prompt_number": 16,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317f9f5f8>"
-       ]
-      }
-     ],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Berkeley"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "berkeley()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}0.924 & 0.0 & 0.0 & 0.383j\\\\0.0 & 0.383 & 0.924j & 0.0\\\\0.0 & 0.924j & 0.383 & 0.0\\\\0.383j & 0.0 & 0.0 & 0.924\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 17,
-       "text": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 0.92387953+0.j          0.00000000+0.j          0.00000000+0.j\n",
-        "   0.00000000+0.38268343j]\n",
-        " [ 0.00000000+0.j          0.38268343+0.j          0.00000000+0.92387953j\n",
-        "   0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j          0.00000000+0.92387953j  0.38268343+0.j\n",
-        "   0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.38268343j  0.00000000+0.j          0.00000000+0.j\n",
-        "   0.92387953+0.j        ]]"
-       ]
-      }
-     ],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/berkeley.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAKwAAABBCAQAAADm4ocPAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAC5UlEQVR42u2csZGbQBRA3/eogY0c3gwNOCB2\nhksgcAOoBF0JXAlSA545lWBKOGWOmbnQESV8ByBpEcg6n/dzPs9/JLD6f1me0O5K7EiUlMg3npNW\nuBR3+jVthavEDXzW+8VkJETq1DV+eOtL+l9xsUa4WCNcrBErKZLW9/GtL+i17U7rQRu/Y41YaZOy\nusT3/3L8TOvB+1gzXKwRLtYIF2uEizXCxRrhYo1wsUa4WCNcrBEu1ggXa4SLNcLFGuFijXCxRrhY\nI1ysES7WiNRLjEZIwfkZ2EH3kzKAnbZRWUuj7Siu0ea0BKj5Xe5xcdP0DBRk5wipyPpcU7OadKO+\nOA4oQVHY8DTslaeyjC1lHEdge6yDAiUb9itqwpXcKG6InkRRoeSnNj2N46ftTmDCVqyCnvae+lcp\nzmUKm3EcAaUax5H3Cudzx2VXo77zeHqTstvt/ttt2T62iw8klxy4eOys3WWS5GR9N3Ird5oZRa0p\npQQJBONOAFhs8JIgNY0+xCWUBNDDRWTNTnfRccV2ovVK7u+itOWBWgKbuBV2mA5ewwX2Q0lLLuF4\nP0pB6AeUKK4GAug6KitpCTKSMZc7e9aLKL2Xki27W5lpWEDscY2JbHnky7lMOgDJj/fdMGZvpY4W\nL7d6kDWPsj9/fOdyTzqzY9xs1J489YqXayzZx3bjaZA22gD5JCoq0QNow47tOOhKLlQvilqAJcVm\n08FG5j7UBci49IFMNi/KDS+KWoAFviAMk/uMjjVIQRmt+S/ZR3GNNuyopCCTdohrtCGno5bADz7P\n5J7rK+jmzwAgFTmZ1OZfDXqs57GvqCNQTGeatlv6eewCg9cfv9Xdrfnpe8B/hDHCxRrhYo1wsUa4\nWCNcrBEu1ggXa4SLNcLFGuFijXCxRrhYI1ysES7WCBdrhIs1wsUasUr8V16f3vqCXtvutB70/p9/\nKPdeHyZ6V2CEizXCxRrhYo1IvWDj7p3+89Zd6gp/ATOCLBoZBGluAAAAJXRFWHRkYXRlOmNyZWF0\nZQAyMDE0LTA2LTIzVDE1OjI0OjUyKzA5OjAwNSD48AAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNC0w\nNi0yM1QxNToyNDo1MiswOTowMER9QEwAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAA\nAABJRU5ErkJggg==\n",
-       "prompt_number": 18,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317f9f748>"
-       ]
-      }
-     ],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "SWAPalpha"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "swapalpha(pi/2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & (0.610-0.488j) & (0.390+0.488j) & 0.0\\\\0.0 & (0.390+0.488j) & (0.610-0.488j) & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 19,
-       "text": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 1.00000000+0.j          0.00000000+0.j          0.00000000+0.j\n",
-        "   0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j          0.61029202-0.48768399j  0.38970798+0.48768399j\n",
-        "   0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j          0.38970798+0.48768399j  0.61029202-0.48768399j\n",
-        "   0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j          0.00000000+0.j          0.00000000+0.j\n",
-        "   1.00000000+0.j        ]]"
-       ]
-      }
-     ],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/swapalpha.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAMcAAABBCAQAAADP5XiIAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAEcUlEQVR42u2cMW7sNhCGvwmcLkDANEkXgEHq\nIFCOwFel5juCcgT5CNojeC+QYHmEVROktZADBBbwLhA16SeFtFrtei3bAGXz2fy2kUgNRfHnDEWJ\nK1FiIr/zKWqBafM1f+ifMQu8ilzBT3r9gs3xyojjy7glfvHal5SZk+VIiixHUmQ5kuJKXNTyvn3t\nC3pRvuJHiVlen70jKa60iVlcZF9Lnf/4O277Ze9IiixHUmQ5kiLLkRRZjqTIciRFliMpshxJkeVI\niixHUmQ5kiLLkRRZjqTIciRFliMpshxJ8U7lELucK+YsxZynrEPsZW/nF2bwWHq2OA1SYgH0+rgF\nUh+2QAqcbkZbx/HdYnP/rZs43HPSZ0fUbBarXY61MRRDOdpLJVvt120tQKP+qM/2bzBD+pBDze2Y\nU/HvuGXYDUcp1NzNrA062lfsD8fMz3Z+vuX0MdfjFq/BjHX1lHj2lPPUkyPdcknP/60arKTAjj3q\n0BsDxej2DUaKoecRZv3ODqljDkOObjCUkarlH3m/7QkglkK3GthQiwHt6Y81W4u1x46x8bVncPqW\nDj/k0Axb4hmbRwoCYcw/p8cAiF2O+5eY20hB98jhVlvAUIkBbTAMMjQP1Cwiq8qhLQ13spNK7NQj\nwzgiGJrD2DD5htOW5pIXSEHBFqTGUshuPrCKk1vZixcvu6n/GvHihuPObBztZFnLrdzJXm5lP4xg\nIJbBH1sV7UE8vR660ufuHfqRDVBxOzVUwIsRQ0egOOvpBnQLMuuFUkstFY4ftANKeg10c8m0oaHV\noIEtN1NqmPr1qY1hFF88QX9hox8I+mFaee8JJ3UquZ7Xb11WvrOC4T5Jbqj4CKCtdHh6DSAtXrop\nVHk6cUCLmzXJyT2SfiNe7EPNoo0UUmgL9I/baBhCl9iT8GV0ticVQbfT7up3VusO5W5aBnc9c/Qw\n3cAGPGYKVYVutdGG7UMxWozs6TU8p1kesSm1wR7zTkcW8XS6nY08q3vH2kP5ceYwRezZYB1OovHY\nKBpOw9WMEg6+cmm9ozhabZ9uI2aY/cxqOQtV4ug0AIU+NvhHY+1gZaSiBfxx4qWttBoAtJN2CFXi\nKLHSagNS01NJMQ71XpjdBnjx9HQ4rDgKEKcNUIgHHL/BIR2LxfMX5mgzlHEIj5Q0QD/vFAdfFcsO\nIwDdIJFYoi4Avcia00AM5tJkCXt/68lnKC5PBzEPl3Vqw+5Yv9Na4PELZ64o1p4Gruod4xTuXp86\nOv/zw8C9YHQ8V/9EmzB61OQJUy2KxX822ofOHY838AhRHBbz9LXzGnCXHgguPySUmpf4E+qawSrd\n33nYGULWQri7GAo/s2CVLpfCzlLgXAqFMXkDweotkeVIiixHUmQ5kiLLkRRZjqTIciRFliMpshxJ\nkeVIiixHUmQ5kiLLkRRZjqTIciRFliMpshxJcXVYmxqJn177gl6U7/g16vftOon80e/6nX1lmvzx\nvTdMliMpshxJkeVIitjrrL5/V1/S/Zl/4hb4PyXldxn2dtC2AAAAJXRFWHRkYXRlOmNyZWF0ZQAy\nMDE0LTA2LTIzVDE1OjI2OjM3KzA5OjAwpYIO7QAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNC0wNi0y\nM1QxNToyNjozNyswOTowMNTftlEAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAAAABJ\nRU5ErkJggg==\n",
-       "prompt_number": 20,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317f9f198>"
-       ]
-      }
-     ],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "FREDKIN"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fredkin()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 21,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  1.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  1.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  1.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  0.  1.]]"
-       ]
-      }
-     ],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/fredkin.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJ4AAABsCAQAAAAx1sPiAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAADkElEQVR42u2dPW7jRhiGnwmMVAsE3CZJFYCA\n6xS8Aq/ANqXUp5GPIB3BqtIFsIGk2mp5hPURLGCrIE3YpP9SkJIpS/Ji8Y4oBXgfNdTw43Dm8fzB\nHNMpyEn6nc9ZM8zLt/FrzuxuMhfvc9xNKOMrScu8+X1z6Qr9n7E8AcsTsDyBm1Rnze/7S1fo7dLl\nra1bnsBNtDmzy9yOc/N33tq65QlYnoDlCViegOUJWJ6A5QlYnoDlCViegOUJWJ6A5QlYnoDlCVie\ngOUJWJ6A5Qnk3m6xR6rZe6YRd6OUDW1sjsexphyltP2Th11UG+1268QoxxaogVV0kEpm/fmz2ous\nH5avvjcERRBQ8pEqoOhTKLh/id6Lu6d5iQto+isDaoJyuGLGcji/S6XmEw/D+XJ7dLp0cm3PLK8m\ndscldX/L4XtBMDuMC1iM4wIqninGUVQ0h/egpuG5v/qYqtzyJhrzUgmxodhr892RuCpVQxccRz7R\n0YyjKOPx6I065ixSOU2tppowGoD9Cqcl61jvpRQ0FBBPB9dvXsbANOP+hDogWtbcT1Ops04YO0lQ\ns3qVUkDM9+JqCk61mQ3VENWwoUiLWHGKFZ/ePJ+NCeTF3eudBP0cmO7TcjwbRgupA0jVQdurGGZm\nNvGU5jykx+1cfXC/Ls15SFn3Bhxnom57dJtDt21N47ho4TCdkqGjxtOXu+ZUXfeyi+S6n0r2SQed\nNy22a70dK8q0OJ3xNJt7z71IbvoRbluZfkmblrTRsmaWakrWL3EANDzu4gAKupiPcmujpaJjmQrW\nlNtUYEaZtpPQfDw/n4nzrvO+EF1Qbxe9U3xyr/MmmDDe+MF1TDCsnw//YkDA8gQsT8DyBCxPwPIE\nLE/A8gQsT8DyBCxPwPIELE/A8gQsT8DyBCxPwPIEbjK/qOXnS1fo7dJlru11P2K57tK52wpYnoDl\nCVieQO6H3j9lfbPKO+DfjPllft9Q7pb3IWtut9xmze/PvJVNed/cmLlw9YnNaVeCxzwByxOwPAHL\nE7A8AcsTsDwByxOwPAHLE7A8AcsTsDwByxOwPAHLE7A8AcsTsDwByxOwPAHLE7A8AcsTsDwByxOw\nPAHLE7A8AcsTsDwByxOwPAHLE7A8AcsTsDyBK5aXGv7gY3pOlZ7XmUrItf4733f8xncA/MUvly7M\nca635d0O6uBHfrh0YY5ztX/Ekgr+GQ67eH/p0hznP42P680hPYgEAAAAJXRFWHRkYXRlOmNyZWF0\nZQAyMDE0LTA2LTIzVDE1OjMyOjI4KzA5OjAwVwUBIAAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNC0w\nNi0yM1QxNTozMjoyOCswOTowMCZYuZwAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAA\nAABJRU5ErkJggg==\n",
-       "prompt_number": 22,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317f9f668>"
-       ]
-      }
-     ],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "TOFFOLI"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "toffoli()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 23,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  1.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  1.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  0.  1.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  1.  0.]]"
-       ]
-      }
-     ],
-     "prompt_number": 23
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/toffoli.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJYAAABoCAQAAAC5kMEAAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAADUElEQVR42u2dMW4bRxSGvwmEVE6xrgwkgIEN\nXLsg4BNsjsB0LgIY9AkC6wg0coBALt2qcZdCOoFhwnAdmFXKQAvDB3guuKKWyxWlHxxy18D/sdjd\nx3nDmU875KOggVKQk/QPn7J2uB8/x/Oc3Z1kHt6nOD2ijDtI87z9/TD0hL4nLEsg9zJckwomndAi\naoBUMaGg5jyWkCqqdqM43Y40PW7ktTNXLdbXl3F5oElF1gfz9VnFnDLgA/OAkjOqIOCMWdOiOWNK\nUAQBJRdM+iJ9eQEVQdl69e71PPPsDibrVXO8WMUomAa84mLdouCKyWqK61hJ1Rvpydts13udWdbh\n3rOWnTu4pgBmnLci58xaC7eEWFL0RnbkHY+DyYrzrcibNKHckFgzbV1Nt/KayB15R+Mkcy3ydOez\nxW2RNAcqXt88sREp7tFT72jyzu4kbxF5x+AWW9NcrA5xCmnrM3AduTWv9cplLLux3CXyUeusqLnc\nKCgqWh/y2x/415HdeQ1HeBc7dlF6yjRdL70K2gtvz7z7Lcy9OFhRCpBmlJQUaX5dKMYi/c5ZehOX\naUbFb1Gniulq+baKz06kL6/dDqi46en7K0p3tppQtYvHe/cu5uWusw56Z936A1ocNy8X/iItYFkC\nuZfh4yxl4DPgfYZ+fsw7uZT318qZBvUnxF9Dj2IbL0MByxKwLAHLErAsAcsSsCwByxKwLAHLErAs\nAcsSsCwByxKwLAHLErAsAcsSsCwByxKwLAHLErAsAcsSsCwByxKwLAHLErAsAcsSsCwByxKwLAHL\nErAsAcsSsCyFvBs2MmxomXJF8P9qY++4HiP70+5U8LnZ37WMX4ceTZfcO1n35fF6K1yZ/ubL0MPZ\nZHx31lVzWsfDoUfTZWRv8FHzEoCvzXFUjOzOAkgFL/g33g09jm0G2W+4m6jTx6HH0M/IluG4sSwB\nyxKwLAHLErAsAcsSsCwByxKwLAHLErAsAcsSsCwByxKwLAHLErAsAcsSsCwByxKwLAHLErAsAcsS\nsCwByxKwLAHLErAsAcsSsCwByxKwLAHLErAsgdHJStN0xQVv02T/vrKPbfMfLw7OA97yEwD/8cfQ\ng+kytjvrSaMKfuHR0IPpMrJNA+PejvINoDbIRYGrlvIAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTQt\nMDYtMjNUMTU6MzM6NDgrMDk6MDB+qGOZAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE0LTA2LTIzVDE1\nOjMzOjQ4KzA5OjAwD/XbJQAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNSAFXAs5AAAAAElFTkSu\nQmCC\n",
-       "prompt_number": 24,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317f9fdd8>"
-       ]
-      }
-     ],
-     "prompt_number": 24
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "SWAP"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "swap()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 25,
-       "text": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.]\n",
-        " [ 0.  0.  1.  0.]\n",
-        " [ 0.  1.  0.  0.]\n",
-        " [ 0.  0.  0.  1.]]"
-       ]
-      }
-     ],
-     "prompt_number": 25
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/swap.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIUAAABBCAQAAABVqq8VAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAACdklEQVR42u2bzW3bQBBG3wRC7nvKMQBTQA4s\nIBe2QJegAnKhS6BLsBoIYJYQlmCWYAJqICxhciD9WZZ/gMBLIgLm8bLSLlerx5ldSguakxP7xTFr\nh+/x2X/m7G6XeXhHv97KhLV5+/u01cD/f0KFCBUiVIidVVn7+7Lh2L/mHXtEhdh5n7O7zDH2Pse8\nY4+oEKFChAoRKkSoEKFChAoRKkSoEKFChAoRKkSoEKFChAoRKkSoEKFChAqRe6PwDEvUFEwcqLyz\nPQWAXz+VHjf85g1GK6n8Zjm34umf0j7v/5iv4lkP2rPXt6T5/bmGlvulpuHPUkrcza0cWh5Ozk74\ncn7D78c2b33WR49VE8RKCp8AWK40HaWl+TqTrATwiW5pBVDM7y41zDV+Q2K/blCsPVcsX9wnegAf\nGKnnGvq5ZDW91HV0S/05E+mCVfhAz4PdWWOFcr1bZoBE/zgXKCYqH+hfu/pWUnK4YBXgV9wADfcK\n+47akiVGOkornjVP4Aewk7iw1lprqPjm47pjXXkFgXk9sFsargB8sJGayTuwgdpGpUfNaBUwUNGp\ngy3WDmDlqLBKG4fXaDJUikBHTVJ6lH7w3nsOb8wWl6wCTu4MhhMVtUrlSdtFiXfPU2Qr1k6QZA0D\nUGs5xQcbvAPw0YY5PaxiT2GD92AtE42Vy7RaGxulyJq3WCSSQ0V11qp4Wfr47dxHj1WjYrk9enFN\nn9aCtVeFfyF+jolQIUKFCBUiVIhQIUKFCBUiVIhQIUKFCBUiVIhQIUKFCBUiVIhQIXaZH1z9vuHY\nf2Qe+7o76WseF7WTflmEChEqRKgQubeEMj8R/C6Zn3T+C6wjCs9rKuD8AAAAJXRFWHRkYXRlOmNy\nZWF0ZQAyMDE0LTA2LTIzVDE1OjUyOjAxKzA5OjAwaA2JzQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAx\nNC0wNi0yM1QxNTo1MjowMSswOTowMBlQMXEAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwL\nOQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 26,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317f9fe48>"
-       ]
-      }
-     ],
-     "prompt_number": 26
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "ISWAP"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "iswap()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0j & 0.0\\\\0.0 & 1.0j & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 27,
-       "text": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 1.+0.j  0.+0.j  0.+0.j  0.+0.j]\n",
-        " [ 0.+0.j  0.+0.j  0.+1.j  0.+0.j]\n",
-        " [ 0.+0.j  0.+1.j  0.+0.j  0.+0.j]\n",
-        " [ 0.+0.j  0.+0.j  0.+0.j  1.+0.j]]"
-       ]
-      }
-     ],
-     "prompt_number": 27
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/iswap.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIoAAABBCAQAAACkofSYAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAACqklEQVR42u2bwW3bMBRA3y98L3jqsYA6QA/q\nvRetwI7gFeQRbHQCe4EC0QjRCNEIMZABWo3weyAtx8lPYSCUmgD/CQYIUaLEJ/KTFiFRSiK/eCha\n4HX81p8li1sVvr0H3SwoIyPbsuV9WL4Kbx+XYuBSDFyKwUqaouV9Wr4KEvhctBajtxSDlfYliyvc\n7q5CR3koWwtvKQYuxcClGLgUA5di4FIMXIqBSzFwKQYuxcClGLgUA5di4FIMXIqBSzFwKQYuxcCl\nGJReNn0RCUQqRg402smaCkA359Rp+VM3IDWN7qZzG87vfvuy72NNtOjG9tmemjtFYU9IR6Rj2Kb9\nCi1/cipwMx11f1FKQHNOy21K/euqr9tm7z466DeQmkpHAE7Pv6OWkJ49QWoAHenyUVClfbmUMf1A\ndwTW897zcjElK9CRPsniSEw59CklMeVJTUeXc58zEt6xFAnSyl5q0IGee7mRVqopJnQ5UgT6U8zI\n7aTRgd5uD1JTc3jHUoi6I6Tnqj/YAS13U7foiBIkcKSjlurReQH0AHLRVmQrW2lp+KLHeaXMGmgJ\nhMuAqbDnZkrfsyYqCne0xBxKI2saGm7ZPzpPaa4P72840OpIpAOQZlpQ3XAOoN001HZEQu48tR60\n157Di1FlZuYOtJFD7gTnmcbwSEqcUmdVefzR7mkHWor5J2+nygZpGYA4DcroIIN2AHqUgR6kYU0l\ng/YgW0ZaqXWTJ29RWGDiBgtM3qpTdFFonsaFlHuZKnHV122zt5Q0UuSJV2/nXqb+P/6H0MClGLgU\nA5di4FIMXIqBSzFwKQYuxcClGLgUA5di4FIMXIqBSzFwKQYuxcClGKwKf+j8dfkqSMX3orU4zv7i\neontXS2GvVdcioFLMXApBqUXw8p+S34tH8sW9xf1E5dpw+UpcAAAACV0RVh0ZGF0ZTpjcmVhdGUA\nMjAxNC0wNi0yM1QxNTo1NToxNSswOTowMLI0tjkAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTQtMDYt\nMjNUMTU6NTU6MTUrMDk6MDDDaQ6FAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAA\nSUVORK5CYII=\n",
-       "prompt_number": 28,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fa3208>"
-       ]
-      }
-     ],
-     "prompt_number": 28
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "SQRTiSWAP"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sqrtiswap()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.707 & 0.707j & 0.0\\\\0.0 & 0.707j & 0.707 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 29,
-       "text": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 1.00000000+0.j          0.00000000+0.j          0.00000000+0.j\n",
-        "   0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j          0.70710678+0.j          0.00000000+0.70710678j\n",
-        "   0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j          0.00000000+0.70710678j  0.70710678+0.j\n",
-        "   0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j          0.00000000+0.j          0.00000000+0.j\n",
-        "   1.00000000+0.j        ]]"
-       ]
-      }
-     ],
-     "prompt_number": 29
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/sqrtiswap.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJYAAABBCAQAAACZM5X+AAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAADDElEQVR42u2cy43bMBBA3wRugKccF1CuC+Sg\nlKAWFCBAzmpBLsEuwW4ggFXCqoRVCTawx1ziEiYHUbbsbLA7Ma31BvN0oT4kyIfhiBYBi5IS+cFT\n0gYv4U6/pW1wlriDTzqfTMYLyCJ1ix/eekjvCZdlwGUZcFkGZlIkbe/jWw9o3Je0Y9PWI8vATNuU\nzSWO08v4mXZsnrNMuCwDLsuAyzLgsgy4LAMuy4DLMuCyDLgsAy7LgMsy4LIMuCwDLsuAyzLgsgyk\n3mR9BfKd+ys1vdP1NXs+uSzJuL+dXWsb00dWxXJ8KoGSjD1rCgIZgM6lGkrDNnwvWHIKjfWl4PjF\nv039vf1ZNOnB4oX72fAEOY+KworQ12ShsOivKtT8iqXApn9GYcF21FpAY+2ah+GZ1/bFfkyd4A9x\npZ1+AcnJdA8QrzfkEvpYIUgOoHua+AxA1l+Nd+jv6JJAde3OTypLsmFwI6Ic3dOCduwo++u0fUlK\n4hSTnIYm3j9nT/ivZA1xJUFqWUkO2tGylY3UksWs08RMFGiHnHQQXGhH+1wESU7OVd+EE8iSIKs4\nrcZxVeqS0EeCfmUJ1DzG6dVQSpDAjoZcspPmAugaZBRbspCF1BR80t21ZV05wVPxQHVIzkOaDoRx\noo6JfhNLWypKReGRmvJQq6SioOCB1aGWUvzry+bmEryuWVL3MXacTrqnpAGQ4rDhP2dI3M1hSdBQ\nEg6TMNe1ttqy/kvWujpXz1naglRAfZJTStZxMh3XSt1I0VDKR3UG1c3pRJyOKRalS0pp4CynDBqC\n1HRAeVxUSKcNgO6k69+EUlCRSactyII9teTxBVAKkyxIYZpFKVs2ZOfL0yF7KRSnmef47Hmty/ty\nyTHNz52GcP6u6s/jkrJ97t5p6RaYRtby8iZugUlk/bFqf6f4xz8DLsuAyzLgsgy4LAMuy4DLMuCy\nDLgsAy7LgMsy4LIMuCwDLsuAyzLgsgzMEv9VxOe3HtC4L2nHpvNJNize5nh3m6z/Fy7LgMsy4LIM\npN4Ku7uhf3a4S93gbzeo2bUqG516AAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE0LTA2LTIzVDE1OjU2\nOjM1KzA5OjAwGyYKRwAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNC0wNi0yM1QxNTo1NjozNSswOTow\nMGp7svsAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 30,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fa34e0>"
-       ]
-      }
-     ],
-     "prompt_number": 30
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "SQRTSWAP"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sqrtswap()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & (0.500+0.500j) & (0.500-0.500j) & 0.0\\\\0.0 & (0.500-0.500j) & (0.500+0.500j) & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 31,
-       "text": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 1.0+0.j   0.0+0.j   0.0+0.j   0.0+0.j ]\n",
-        " [ 0.0+0.j   0.5+0.5j  0.5-0.5j  0.0+0.j ]\n",
-        " [ 0.0+0.j   0.5-0.5j  0.5+0.5j  0.0+0.j ]\n",
-        " [ 0.0+0.j   0.0+0.j   0.0+0.j   1.0+0.j ]]"
-       ]
-      }
-     ],
-     "prompt_number": 31
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/sqrtswap.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAJAAAABBCAQAAACULeW5AAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAC8ElEQVR42u2cTW7TQBSAv4fCGs0KWCGZLRIq\nvoKv4K5Y5wrOEZIjNBcAdY6AN+zrE6BG6q4rfITHwo6d0KJHYGJT9L6q0qQzevJ8fvMTT1JRUiKf\nuEsa8HRe8Fm/pgu3SHx5d7qaVMcDpOB5ynjP5u3Ov48LMnBBBi7IYCFF0ngv5+4Qr3gtCcN5Bhks\ntE4ZLnE+/gn33Kfsk2eQgQsycEEGLsjABRm4IAMXZOCCDFyQgQsycEEGLsjABRm4IAMXZOCCDFyQ\nQeqDw99APvIubcRzHlZOLkgy3s19+noK02fQkg1IoCSjZUuhUZZkALoaSyDroZRT6GYfQArGJ991\n2mfqj6BJf1gb9VnXgitC175/veamb1HxvS8FrodWt0dRAtrXVHzpSkNdQZGyR1NP0l3+5GTaArDP\ni0guocsJguQA2hL7VpB1f+tvatv9gm4ILM95wZMKkmzfsb0ObakBtGFH2dVQdyUpuzrJicS+9iEt\n4b8R1OUPaEPNrVxLJdkwh8R+ZgnU+zmml1loQ/14nkhOzvYJC5IgV/3QOcwf9JINUHEzDJ1IKUEC\nOyK5ZAdBAugW5CiHZC1rqSh4q7tz9uDcq1hJRtnf4+Uw4wDdqiRXVFwCaCM7SlqNIA2l7PoBVrKT\nAmgoiAeRz79+AWfPIN2yoQKQMOaPFMMR9Ypx8o3D8h0pCfvZSrdaa832l7PQUxYEWoMsgeporhh3\nMs2BoHIojdr2gzL+PMimYYqN4oZSIhzNFUEqGqAch5020mgE0J001CAFSzJptAZZ01JJrqt+o1gK\nkwyyKTaK3HJNdrTRC49t6cY2h61PvILEG8Vp3mpEwmH+9Ju8B/d/bHPelekUphG0+fsQczGJoOEN\nwxPEH5gZuCADF2TgggxckIELMnBBBi7IwAUZuCADF2TgggxckIELMnBBBi7IYNF9hiIZ7+fuEBd8\nSPm9R0n8rynWc3/2RwqSnnb4EDNwQQYuyMAFGaQ+9nkz+zfnL/iWMtwPx46+3QLFvwcAAAAldEVY\ndGRhdGU6Y3JlYXRlADIwMTQtMDYtMjNUMTU6NTc6MTcrMDk6MDAhXnctAAAAJXRFWHRkYXRlOm1v\nZGlmeQAyMDE0LTA2LTIzVDE1OjU3OjE3KzA5OjAwUAPPkQAAABR0RVh0cGRmOlZlcnNpb24AUERG\nLTEuNSAFXAs5AAAAAElFTkSuQmCC\n",
-       "prompt_number": 32,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fa36a0>"
-       ]
-      }
-     ],
-     "prompt_number": 32
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "SQRTNOT"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sqrtnot()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.500+0.500j) & (0.500-0.500j)\\\\(0.500-0.500j) & (0.500+0.500j)\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 33,
-       "text": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 0.5+0.5j  0.5-0.5j]\n",
-        " [ 0.5-0.5j  0.5+0.5j]]"
-       ]
-      }
-     ],
-     "prompt_number": 33
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/sqrtnot.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIMAAAAYCAQAAABzNYZtAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAB2UlEQVRYw+2YvW3kMBBG3xjbgKILDbABByrA\nCR1cAesSuCVIJVAlSA0cYLWgxNFdsFuCF3AFKmEckLJXa9954SMF29hRQog/Gj5+HA4lytlglXY4\n+c39Al5f6c9PjYF7rfNTEJ96xIv8Tn8FO2MAzhiipY4N75j84vE/une6/wYYxPC4RAj95Bhw/BEP\nNDqCGBxAACOWkoKRPqy4FJRHvXc6ZvNMkz74f9QZvIJly93zm6nU4uYlLB6jsMUrGFrsKV/52LNk\niHQ0ADSUUgHonrDyFUa72KrGSwmUWuseGGPLmiKfa4thEANR1CMbKjEzQP1U1JEeBxwFQx1zYlgl\nzsiu/lozaQHQQTpabiKgEjOb9Ihjo/3xAM96geu0Xmu9Shu5D92TAk8dFHCghWANW6k0gHm9yu+t\ne/KUPeemWGNYx/KBFgA0bIxwFuxeTXyX0aulMWhHQwUgxZEWAB3oaCOSYXY4WoZvhAF0AHFARfdG\n7Yuwa9YS9SAW5sr58hiAJkxwSoLF4vDiYu0mAtlxSysWxOG4mZQjTjwGK15sZj9zp088cIc5qW+J\nPbFl8vQpfzLdU5x2IdLFA+OL5cew+D7/iGXHkPE6lNDOv12A9Gq4zB7TAX6kHvAJrGBwKPPZqIoA\nAAAldEVYdGRhdGU6Y3JlYXRlADIwMTQtMDYtMjNUMTU6NTk6NTgrMDk6MDBNlTmNAAAAJXRFWHRk\nYXRlOm1vZGlmeQAyMDE0LTA2LTIzVDE1OjU5OjU4KzA5OjAwPMiBMQAAABR0RVh0cGRmOlZlcnNp\nb24AUERGLTEuNSAFXAs5AAAAAElFTkSuQmCC\n",
-       "prompt_number": 34,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fa38d0>"
-       ]
-      }
-     ],
-     "prompt_number": 34
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "HADAMARD"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "snot()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}0.707 & 0.707\\\\0.707 & -0.707\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 35,
-       "text": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 0.70710678  0.70710678]\n",
-        " [ 0.70710678 -0.70710678]]"
-       ]
-      }
-     ],
-     "prompt_number": 35
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/snot.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAGMAAAASCAQAAADlTKh6AAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAA1UlEQVRIx+2VsQ3CMBBF36GUNFSUkYIYALGC\nV2AFZsgIHoQVqHCTigbEAEhZIQ39UThEVCTFWURRvhvLOt33t/73iWIJuVL1FuWc9WRKS2bbjkrL\nXqnOmBNY2Lf8ByYiw9pUHcQRzROoOcazfsONToYGgQsbrYFSboR0IpKbSut206TlmUo2jL+/9YCa\nJVux5Gz0niwbEd0jrdLyZBqSXLvFp7t8Z+PFw5Z1MtmYZfyGOA4gXpwU4inYi0+oQ00XfkCNw9my\n6myqUcF6buQDxumOp7WMN6YSh0FlxqyEAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE0LTA2LTIzVDE2\nOjAxOjEwKzA5OjAwJXr5aAAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNC0wNi0yM1QxNjowMToxMCsw\nOTowMFQnQdQAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 36,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fa39e8>"
-       ]
-      }
-     ],
-     "prompt_number": 36
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "PHASEGATE"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "phasegate(pi/2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0\\\\0.0 & 1.0j\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 37,
-       "text": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[  1.00000000e+00+0.j   0.00000000e+00+0.j]\n",
-        " [  0.00000000e+00+0.j   6.12323400e-17+1.j]]"
-       ]
-      }
-     ],
-     "prompt_number": 37
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/phasegate.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAKgAAAAWCAQAAAD+gh86AAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAC9klEQVRYw+2Yz43bOhDGf/OQYy48vWMABikg\nYAtMCUwJ2hLkEuQS7BJWJaxKWCEFBKsWeMl9ciAlU86ukrwV87JBPsGwSM2MzM/zjxRlT0inh10N\nVoZ40GFPi//830v60/CX0J3xwgkVu/1UzGps1uMaeFVtqR6/DAYdipmBiSY9mDOuOLwey6UTsETO\neGJhCeCsU5bqOLKFRg8gBpfypEZp5ayxKqO660VX3BsUoyi03GEUPIrNT+9Xsh0PKzunrNnRKYTF\nkuVEyDIBv/lbTNZtCNzRXOYKGb9t4+eviiGvMX1Aj5jFJ7N3ce0nVtzinw6b/eg4y2ZLk94wh3n4\nTn0O9GJxetaeI50Y0Ei8vKcGflUOjWxkL3H09IRiyqVsp5GhlBMHaUYcE9uwOmJoxYAOGBKRw+o9\nu+OXECoOx3lDwOvIMPsw6MjAg9xKK/bihWIIGNAx6TDm+U7u5UHu5F7upFukLRF0VNEIEog5j45U\n9dBqRWleLCm4386lQOYCU3qsAT1LJ0H7TOlHaXG0tPIhESgeg13pRAAJ9HqQRs/SlmWNQF+MGg7l\n2yoSKv75Rgr8ezUervPcPJYlh0pgEg+M+AsJiRw50fJx1ks64rKPJrk+hb/YqxRglmyNtPR6iZAy\ne7/mney5/qmyh/4QXGqexHDiBlYbwgP3BXlpzjFeWWj0RnxJVJlhJTBpL3YpiHU9dN+d7H/y90yE\n9nJagt4vxeiKPFkHfjnjiwIW5g5VPJOOgNOeb/GFT/syULuxD3IJck8A6XJjb/N9g5VRB5COSCvJ\nX420jImYRW+mKhHTEzKBDQMQ18Um5Wyx3GIEYEp6YtmVwG9Qr7F/hhWTtwHbjfvtLJ2/7fIkzM3/\nI1ot7oU29s/4k6NG0OE7wdinBDP3D5ci9ER4J1gdqYjfktAfg/b4xw47tg5ApKPyee0LJhT0wGOn\nTeapTYQYah+N1G7sa+Ox8NUnt6QaqUznC/fQ3xF/Cd0Ze4f8m523srXxns/7GvwKWW8ohN5UGtUA\nAAAldEVYdGRhdGU6Y3JlYXRlADIwMTQtMDYtMjNUMTY6MDU6MzQrMDk6MDCa+3p8AAAAJXRFWHRk\nYXRlOm1vZGlmeQAyMDE0LTA2LTIzVDE2OjA1OjM0KzA5OjAw66bCwAAAABR0RVh0cGRmOlZlcnNp\nb24AUERGLTEuNSAFXAs5AAAAAElFTkSuQmCC\n",
-       "prompt_number": 38,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fa3710>"
-       ]
-      }
-     ],
-     "prompt_number": 38
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "GLOBALPHASE"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "globalphase(pi/2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0j & 0.0\\\\0.0 & 1.0j\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 39,
-       "text": [
-        "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[  6.12323400e-17+1.j   0.00000000e+00+0.j]\n",
-        " [  0.00000000e+00+0.j   6.12323400e-17+1.j]]"
-       ]
-      }
-     ],
-     "prompt_number": 39
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/globalphase.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAI8AAABBCAQAAABCiD/cAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAACwElEQVR42u2czW3bMBSAv1f4XrCXHguoA/Sg\nAXrRCuwIXkEZwUE30AIFohGiEeIRYsADtBzh9aAf24n70hSUrRTvMwzZskj7fSCfSNG2KDmRH+yz\nVvhafur3nNWtMn+8vd5cUMYzZJO3vnfXDGb5uB4T12PiekxWUmWt7+OV4/mUNx5vPSYr7XJWl7kt\nvp593ni89Zi4HhPXY+J6TFyPiesxcT0mrsfE9Zi4HhPXY+J6TFyPiesxcT0mrsdkIXqksF+V8GRP\neLpnHnIvA54GUXG4etj11/GkohofT8dtuDUrWveLixIo+5KapJZG05vWo51s+cUHTSC11HzTpF0v\n6EhOpLMCHduJRAJJ7mm1ARpqZl+RnblzaervoLcE1mcPii9cH460IAWlNtpyy0YCaCJJ+cb1nJA4\nky+kZPdCuUK3QKCWANoR6LV0xP9Gj5SUNMOTIFEquZMAVGynYzbyII9yLw9yP36ZQAr61rdV0QQS\nSUP+2TJ765k194xBAwn4fMgw2oLUlHQEhr0SafVG1tpIrYdUHWlPqlsfZZzZz14X0PP0PDXIeoa2\nfVeT4qS7BT16JvWQmI16crKQcc/EWjuKQ9inmUkiO22kmEZJs7eeRemRQB/4YbR01LWkYqctUOpL\nyTwblxgWRuHQvaSiBKkoKIgCLXEaBa3pgHSccsd8JQV3BAHY9cqkIOuC8Vk0643NP5S5mx6FYVsM\n20g0ytWUOd7fui2hc7XjFxfGljJ1nlJbo1w/HpqVBejRlurcBNOedMpm/inFIvSA3nBuxh5o/lRC\nAheYkF5m3PMXnOsm1vlJ0/xjHlhI61kursfE9Zi4HhPXY+J6TFyPiesxcT0mrsfE9Zi4HhPXY+J6\nTFyPiesxcT0mq8w/jP9y5Xi+Zo7n+gs5S35/71wmrsfE9Zi4HpPc61yZ/4Xg1bzPW91vAqzFTU39\nbEgAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTQtMDYtMjNUMTY6MDc6MzErMDk6MDDMNoXmAAAAJXRF\nWHRkYXRlOm1vZGlmeQAyMDE0LTA2LTIzVDE2OjA3OjMxKzA5OjAwvWs9WgAAABR0RVh0cGRmOlZl\ncnNpb24AUERGLTEuNSAFXAs5AAAAAElFTkSuQmCC\n",
-       "prompt_number": 40,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fa3a90>"
-       ]
-      }
-     ],
-     "prompt_number": 40
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Expanding gates to larger qubit registers"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The example above show how to generate matrice representations of the gates implemented in QuTiP, in their minimal qubit requirements. If the same gates is to be represented in a qubit register of size $N$, the optional keywork argument `N` can be specified when calling the gate function. For example, to generate the matrix for the CNOT gate for a $N=3$ bit register:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "cnot(N=3)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 41,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  1.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  1.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  0.  1.]\n",
-        " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  1.  0.  0.]]"
-       ]
-      }
-     ],
-     "prompt_number": 41
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/cnot310.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAABeCAQAAAAJMMufAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAABlUlEQVR42u3aL04DQRTH8e8QJH8yKFAkm3CC\nXmGvsCQIkEWh2yO0GoUkuOUAiBIkansESFAYQgMCO4hugbCyb8Ir+f1qNhXvfXb6OtlkNjAiT7aB\ntzylQ8pkzpm1vwYI7TlCCy20gwgttNAOIrTQQjuI0EIL7SBCCy20gwgttNAOIrTQ/w29nqdsKDki\ncJOuc1TPsNKhDA0lDXcUoQlVBnUy/lBRExOUlAkiF/TNexiXizTExAKdSDChsO1iPR4Dxmn267sx\nA9sm1uhe96+XbilsmwTjA/1jrtqrfeCpvT6kNu1iPNP1fKJ/znSCie+ZntLv/JgVU+Mu5ttRu1cs\nVvp7P/G70jCkDuXXKveoGXb2kyWT4SWVEBlR8MIHm0RO06N5hzxv1oTIGXBuvcbzZHpgSrNwD3nI\nK/poKrTQQjuI0EIL7SBCCy20gwgttNAOIrTQQjuI0EIL7SBCCy20g6wk2vzEtj23rXgn8UAvR/VA\nufyNd7LBJVsAPHNiXz7PeBy0ZNhj1758lhPbEHltL2dpx77+J5q23uRHgcIpAAAAJXRFWHRkYXRl\nOmNyZWF0ZQAyMDE0LTA2LTIzVDE2OjI4OjMzKzA5OjAw8s52gwAAACV0RVh0ZGF0ZTptb2RpZnkA\nMjAxNC0wNi0yM1QxNjoyODozMyswOTowMIOTzj8AAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUg\nBVwLOQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 42,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fa3cc0>"
-       ]
-      }
-     ],
-     "prompt_number": 42
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Furthermore, the control and target qubits (when applicable) can also be similarly specified using keyword arguments `control` and `target` (or in some cases `controls` or `targets`):"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "cnot(N=3, control=2, target=0)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 43,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  1.  0.  0.]\n",
-        " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  0.  1.]\n",
-        " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
-        " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  1.  0.]\n",
-        " [ 0.  0.  0.  1.  0.  0.  0.  0.]]"
-       ]
-      }
-     ],
-     "prompt_number": 43
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(filename='images/cnot302.png')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAABeCAQAAAAJMMufAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAABmUlEQVR42u3bMUoDURDG8f+TNJbPCwRWbGxz\nhT2ATexsLDZHMEfIDSRip1XS2W6OoNjZJeAFEgTB8lm4UUnaGZjA96XIY4vZH8Owr9h9FDx+DFlT\nWDLwqJ4K9kmZJRmAVTm1r99LEwd1vyNDlW75MG+KU6fX3XJTTuzrHzmYKRtGP+Tu37opHp0GSBec\ncV82HrVdOg3AJ68+ZE+0Y4QWWugAEVpooQNEaKGFDhChhRY6QIQWWugAEVpooQNEaKGFDpCEx8tP\ngHPgzQnt9kquhrLwqX2Q4yG00EIHiNBCCx0gQgstdIAILbTQASK00EIHiNBCCx0gQgstdIAcJLrn\nUTRlaq5JKbPwOL/l0Ok0pKXiiUcq2jR06Ir56dqGKblATV0gM2Vifg/jchVtt6qpu1VrfTzYejwa\n7vaujWhsb2KNrsp891JZ/R4TNor1C/0rHrpVH3jv1pfMTO9iPNMz8u5MF7ZzHnWmX/bnNzVYf41g\n/jhqqf53mszztvtROw1jZn8bSqppGVnvig4fqaTMDQO+gGNWjO038m8/HOaCCn0Y0wAAACV0RVh0\nZGF0ZTpjcmVhdGUAMjAxNC0wNi0yM1QxNjozMDowNCswOTowMGu/0NoAAAAldEVYdGRhdGU6bW9k\naWZ5ADIwMTQtMDYtMjNUMTY6MzA6MDQrMDk6MDAa4mhmAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYt\nMS41IAVcCzkAAAAASUVORK5CYII=\n",
-       "prompt_number": 44,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317faa048>"
-       ]
-      }
-     ],
-     "prompt_number": 44
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Setup of a Qubit Circuit"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The gates implemented in QuTiP can be used to build any qubit circuit using the class QubitCircuit. The output can be obtained in the form of a unitary matrix or a latex representation."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In the following example, we take a SWAP gate. It is known that a swap gate is equivalent to three CNOT gates applied in the given format."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "N = 2\n",
-      "qc0 = QubitCircuit(N)\n",
-      "qc0.add_gate(\"SWAP\", [0, 1], None)\n",
-      "qc0.png"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAIUAAABBCAQAAABVqq8VAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAACdklEQVR42u2bzW3bQBBG3wRC7nvKMQBTQA4s\nIBe2QJegAnKhS6BLsBoIYJYQlmCWYAJqICxhciD9WZZ/gMBLIgLm8bLSLlerx5ldSguakxP7xTFr\nh+/x2X/m7G6XeXhHv97KhLV5+/u01cD/f0KFCBUiVIidVVn7+7Lh2L/mHXtEhdh5n7O7zDH2Pse8\nY4+oEKFChAoRKkSoEKFChAoRKkSoEKFChAoRKkSoEKFChAoRKkSoEKFChAqRe6PwDEvUFEwcqLyz\nPQWAXz+VHjf85g1GK6n8Zjm34umf0j7v/5iv4lkP2rPXt6T5/bmGlvulpuHPUkrcza0cWh5Ozk74\ncn7D78c2b33WR49VE8RKCp8AWK40HaWl+TqTrATwiW5pBVDM7y41zDV+Q2K/blCsPVcsX9wnegAf\nGKnnGvq5ZDW91HV0S/05E+mCVfhAz4PdWWOFcr1bZoBE/zgXKCYqH+hfu/pWUnK4YBXgV9wADfcK\n+47akiVGOkornjVP4Aewk7iw1lprqPjm47pjXXkFgXk9sFsargB8sJGayTuwgdpGpUfNaBUwUNGp\ngy3WDmDlqLBKG4fXaDJUikBHTVJ6lH7w3nsOb8wWl6wCTu4MhhMVtUrlSdtFiXfPU2Qr1k6QZA0D\nUGs5xQcbvAPw0YY5PaxiT2GD92AtE42Vy7RaGxulyJq3WCSSQ0V11qp4Wfr47dxHj1WjYrk9enFN\nn9aCtVeFfyF+jolQIUKFCBUiVIhQIUKFCBUiVIhQIUKFCBUiVIhQIUKFCBUiVIhQIXaZH1z9vuHY\nf2Qe+7o76WseF7WTflmEChEqRKgQubeEMj8R/C6Zn3T+C6wjCs9rKuD8AAAAJXRFWHRkYXRlOmNy\nZWF0ZQAyMDE1LTAxLTEzVDEzOjIyOjM3KzA5OjAwAgDFRQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAx\nNS0wMS0xM1QxMzoyMjozNyswOTowMHNdffkAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwL\nOQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 45,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317faa7f0>"
-       ]
-      }
-     ],
-     "prompt_number": 45
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U_list0 = qc0.propagators()\n",
-      "U0 = gate_sequence_product(U_list0)\n",
-      "U0"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 46,
-       "text": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.]\n",
-        " [ 0.  0.  1.  0.]\n",
-        " [ 0.  1.  0.  0.]\n",
-        " [ 0.  0.  0.  1.]]"
-       ]
-      }
-     ],
-     "prompt_number": 46
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "qc1 = QubitCircuit(N)\n",
-      "qc1.add_gate(\"CNOT\", 0, 1)\n",
-      "qc1.add_gate(\"CNOT\", 1, 0)\n",
-      "qc1.add_gate(\"CNOT\", 0, 1)\n",
-      "qc1.png"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAMAAAAA/CAQAAAAcEQ9AAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAADJElEQVR42u2cu24TURCGv0GREOV5gqBtKbeC\nJs2mo4BiAw0Nhf0EyHkE+wnAaUFCsjsKGq+QaKBJBC8QS3mBrCIhUQ5FfCNO5ZzRsGi+LTw+xbn9\nO+diyb8ogSd73h3YFSkZ0PKQL9Q0jLT17tGOaCcfeswoFIaKQs2M5N2n3Z5OZoCU1Hq48RJNpWXM\nkXe/duGeTbVSy6WonEtpUv2A/t8F2tDatGU8EpsliMTlIjw3qX+2ioarqFrH3RmJsidDA1X3SYuo\nkLdcZa//0arXBxv9fyHdG8ncKgOW4aVJ/ZNbMqA0ygDTkajNHqDtYo1ub67VmUiStspqzjo4Ertj\nKM94Y3U0pF6+7avPYr0vGGTBR7tDrtEpCPjFD6vLkU5Jm3uXlIw5thqItlzYXfM6eQ8A7ctAZjTc\nl4qKkr7Ovfu0G3YZYIyOOGLOU0qmetjV6e9sBgBoy1RKHXn34250NgP+F0IAZ0IAZ0IAZ0IAZ0IA\nZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IA\nZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0z+JSmJiteIJJrOOlktx1JS8Vxa\nGjWwQjDJAKmZUfCJDxTMpLaeIjskyYQecz4zpyeTWxwq7k52Z4UeY5JCRaWQGFu4mKxas6w7cUq1\nboWK0/yeEZkzQApq7a+XHW21T2nmNmXLkGNt1l+1YcQgdyO5l6AeJ1tlfXq5uw3XZmIMrMzEpCBt\nTj+ATilzL0O5BSh0erNI5xisnZIYk4CCSf7agZLmltKGzHILeS3LXvF+Ee0DF4v4yGCS9nm5it8Z\nmIkdcMXPVfx1ET0GvmdsJbdlGZPlNnW9CS9iAzMlc1u0DRPAzYjyn96EOdte76V3azLfEWszMW2o\ntkaSqLLfBrK/OTOKzQwgWRzeVllQ2ZmJMdgyRhtS524l/0XsmMn68iUVM/pm1mWtGt60dUSS4fLU\nI0mGsH3EuCuS3z1dEgNKfgMPmHPc5R8jpKbHnCd8o+Ak//TDH8aXrLfMg9DNAAAAJXRFWHRkYXRl\nOmNyZWF0ZQAyMDE1LTAxLTEzVDEzOjIyOjM4KzA5OjAw9Ei1rAAAACV0RVh0ZGF0ZTptb2RpZnkA\nMjAxNS0wMS0xM1QxMzoyMjozOCswOTowMIUVDRAAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUg\nBVwLOQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 47,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317faaeb8>"
-       ]
-      }
-     ],
-     "prompt_number": 47
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U_list1 = qc1.propagators()\n",
-      "U1 = gate_sequence_product(U_list1)\n",
-      "U1"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 48,
-       "text": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.]\n",
-        " [ 0.  0.  1.  0.]\n",
-        " [ 0.  1.  0.  0.]\n",
-        " [ 0.  0.  0.  1.]]"
-       ]
-      }
-     ],
-     "prompt_number": 48
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In place of manually converting the SWAP gate to CNOTs, it can be automatically converted using an inbuilt function in QubitCircuit"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "qc2 = qc0.resolve_gates(\"CNOT\")\n",
-      "qc2.png"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAMAAAAA/CAQAAAAcEQ9AAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAADJElEQVR42u2cu24TURCGv0GREOV5gqBtKbeC\nJs2mo4BiAw0Nhf0EyHkE+wnAaUFCsjsKGq+QaKBJBC8QS3mBrCIhUQ5FfCNO5ZzRsGi+LTw+xbn9\nO+diyb8ogSd73h3YFSkZ0PKQL9Q0jLT17tGOaCcfeswoFIaKQs2M5N2n3Z5OZoCU1Hq48RJNpWXM\nkXe/duGeTbVSy6WonEtpUv2A/t8F2tDatGU8EpsliMTlIjw3qX+2ioarqFrH3RmJsidDA1X3SYuo\nkLdcZa//0arXBxv9fyHdG8ncKgOW4aVJ/ZNbMqA0ygDTkajNHqDtYo1ub67VmUiStspqzjo4Ertj\nKM94Y3U0pF6+7avPYr0vGGTBR7tDrtEpCPjFD6vLkU5Jm3uXlIw5thqItlzYXfM6eQ8A7ctAZjTc\nl4qKkr7Ovfu0G3YZYIyOOGLOU0qmetjV6e9sBgBoy1RKHXn34250NgP+F0IAZ0IAZ0IAZ0IAZ0IA\nZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IA\nZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0IAZ0z+JSmJiteIJJrOOlktx1JS8Vxa\nGjWwQjDJAKmZUfCJDxTMpLaeIjskyYQecz4zpyeTWxwq7k52Z4UeY5JCRaWQGFu4mKxas6w7cUq1\nboWK0/yeEZkzQApq7a+XHW21T2nmNmXLkGNt1l+1YcQgdyO5l6AeJ1tlfXq5uw3XZmIMrMzEpCBt\nTj+ATilzL0O5BSh0erNI5xisnZIYk4CCSf7agZLmltKGzHILeS3LXvF+Ee0DF4v4yGCS9nm5it8Z\nmIkdcMXPVfx1ET0GvmdsJbdlGZPlNnW9CS9iAzMlc1u0DRPAzYjyn96EOdte76V3azLfEWszMW2o\ntkaSqLLfBrK/OTOKzQwgWRzeVllQ2ZmJMdgyRhtS524l/0XsmMn68iUVM/pm1mWtGt60dUSS4fLU\nI0mGsH3EuCuS3z1dEgNKfgMPmHPc5R8jpKbHnCd8o+Ak//TDH8aXrLfMg9DNAAAAJXRFWHRkYXRl\nOmNyZWF0ZQAyMDE1LTAxLTEzVDEzOjIyOjM4KzA5OjAw9Ei1rAAAACV0RVh0ZGF0ZTptb2RpZnkA\nMjAxNS0wMS0xM1QxMzoyMjozOCswOTowMIUVDRAAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUg\nBVwLOQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 49,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317faab00>"
-       ]
-      }
-     ],
-     "prompt_number": 49
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U_list2 = qc2.propagators()\n",
-      "U2 = gate_sequence_product(U_list2)\n",
-      "U2"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 50,
-       "text": [
-        "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.]\n",
-        " [ 0.  0.  1.  0.]\n",
-        " [ 0.  1.  0.  0.]\n",
-        " [ 0.  0.  0.  1.]]"
-       ]
-      }
-     ],
-     "prompt_number": 50
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Example of basis transformation"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "qc3 = QubitCircuit(3)\n",
-      "qc3.add_gate(\"CNOT\", 1, 0)\n",
-      "qc3.add_gate(\"RX\", 0, None, pi/2, r\"\\pi/2\")\n",
-      "qc3.add_gate(\"RY\", 1, None, pi/2, r\"\\pi/2\")\n",
-      "qc3.add_gate(\"RZ\", 2, None, pi/2, r\"\\pi/2\")\n",
-      "qc3.add_gate(\"ISWAP\", [1, 2])\n",
-      "qc3.png"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAeIAAACSCAQAAAAztQFdAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAL+klEQVR42u3dO48jWR0F8HPQQIAWLXcTgkUa\nqUYkSGiE7kQkm1QHKyKCGrHSkno+QllCxFR/hLFEjNQlCFZCBF3J5l3BJiRoStpgxZJwtYL8T1AP\nlx/tnkfZ5es5v07ctrtcZffxfdSte2kQeRv8HL/G1yd/2cf22dxHfm4ezb0DEq1v8SerTv2iLOY+\n7PPzvbl3QETejUIsEjmFWE6IyeFH6bbucdv3yC61iWUSdMi7mwGV1XufU+D64EYWtuy25dvWtgXm\nXFk42l7/HV/N8GY9tU+n3JxCLJOwgCUNz6wGWHBhL7afwQzVoTj2ZS4zOATeorQVgBVyLI+221/Z\n8bZ9/5FO3DmnEMtE6BHaEtiWNJY7PdeZPT+4gQwlwATelgADblhasMBAv79kl5baxDKVFF1smSFg\nK3b0aB74+8RqAA45HWAVHDwAoEI296GdN5XEMhXfBpcpclztVJzTPtYskMKhgUNA3VdnmSAAgNUg\n0H4RdO3iWueGD1OIZSopGhYAEnu251HXhpQZSltyYSvmNu7mylBuPH8xagmrh/qgR0f7lvsQwHdz\nH96Oj/HN3LtwMcfwGH9b/0IPdH3Lt1zY6r4/srKtWjPZql47G/3OvOvWao1L9U8m/Y99Oss7N+0x\n4NEcvXNyCZhu/Dq0iOGQjJ5TAztV64W9YDqO5maLmRkaK5kAXbDHJfGXU/7HzlRRn/QY1LElU/FD\nV5ZH1ZbMXCBFPpw/7rAP+fhLYFSZZorGSgDeHuoKEwAKsUyAngVSJF3ZXMMxQwBshWs0XalTDqFd\noAIQur7nTl9aM8EN7mg0FMM9J7/MIi7q2JJ3ZjXqUTfUFTwaawB6JLZqz/Jazb5EXlkArOYwHITZ\n+oSUNfhoa/PbXV6yRSWxTMyCVdYATJDB83Yoccu2pO7L3FFl2duhmCYa6nGYSmI5Ems2h0tayYL1\n7sDLw5c4sDjioMsLoZJYTsaW2HcVk8O9J6TocMTLHy6FSmI5oX0V40N90BagCD9IJbFI5BRikcip\nOi1v64f4zdaorVP4wdyHfX4UYnlL9gW+mHsfBFB1WiR6CrFI5BRikcgpxCKRU4hFIqcQi0ROIRaJ\nnEIsEjmFWCRyCrFI5BRikcgpxCKRU4hFIqermET2oEOGBAErpFZy0U4sZMv1rX7q+W7dC4+0X5aG\n6WhO7cqOP+Gu6Uc/7+0Pip17PO4MBryEa5/RPgdFe78BOf7T3XK4aZ9lQIFXo604WPf3OW7759z/\nqu/2o+q0yIjV9qybMbud3atf9K2E7+blrODoAcACytE0fgmH6fAt9FPz2jUcFsfdZ4VYZJ8ushbQ\nLbCKplsn2fcrJjMbVmT2KFHes45yOPaqjgqxSIeOOV/SA1ajwiveMGcytGn7hWgcqr7NO5TDqdWo\n9pW49PD3T8k7DYVYpJfZNVxbbtpzXAPIcTdUkktkdHRoUMJzcwZtB9gK4KgsZsGCOVI8OfbCcOqd\nFumVdPB9ydv2NfMlcjwHAKvZIEOwEmCNjM1Qmc7QMAVQIx2tG3WKfmkAKolFBhb6xduYDvN4Lker\nN65XdiyRwQ2VaW8rq6zC6p5W8ZEpxCJrGVZdlXh9pne9asW666rcWJi1XyKu3KxQn4qq0yJjfTgd\nc9QAsuEkE6xm3a7faA3rtjLNFAskrK0CWCAgp+86vjLiNBVq2txvmshsWNjWmotMrGlXarTAFFsx\nbB/dvDXFq74blcQiI200u4Ea1f5HN2/NT21ikcgpxCKRU4hFIqcQi0ROIRaJnEIsEjmFWCRyCrFI\n5BRikcgpxCKRU4hFIqcQi0ROF0DMhH/G1yd/0cf22dzHLdNTiOfy9bSXo72OdrJzuTSqTotETiEW\niZxCHJGtaVK3HuPWFOV0PPKk5XIe1CY+A3TIu5sBldX3PKtYz/a0x6Jb2GuYdNUCc65Gy4zIhTpK\niJkgw69A/AOrc5rG5FxZwJKGZ1YDLLiwF7vPYYbq/kD2ZS4zOATeorQVgBVynLz7TE7tCCFmjhSr\nbqLPl6xP3wsbH3qEtgS2JY3lnlkSM3t+YAMZSoAJvC0BBtywtGCBgf6+kl0uxeRtYhZwdtVN7FnZ\nFYJObLyGdLSaQMBO7OhxuEaTWA3AIacDrILrpl6t5pnOXE5p4hDTt2XBml0jYfq223tv+Da4TJHj\nak+1Oe2DzYJ3fMVb3vG2/3pk0k5fbrXRQvtFYP1afv61Xl8iNnV1OtvTBlsix4lWpYlWioYFgMSe\n7X3ctTFlhtKWXNiKua27ubLRCkAAsBh9CuqhvnhTh/gXuy1ga/jTuQ/zvNEDXd/yLRd2YCFMK9uq\nNZON6rUbdx8y77q1WuqdvniPJm6x/nzY3mNgqEY/OZt28cf4Zu5d6Dwe3R5axHDozgXTI1izd6WB\nhb1gug7nZnuZGRormQzTm49L4qdn8jl8iB/PMHJ8n6ezvOon034Oj6btO2bSn1QaL4FBrx7qbRsf\nox+6sjyWAD0cAl7iigtgc4lq9jFfB3+0WhBTNFYD8FbuedGv9DlsmulL7ctpP4epe6f3rJZOtYgP\noGeBdOj8q+G6/ukENQDfvXfrRTUXqACEcYdV3xHGBDe4o9Gw7vLSe3/xJm4T24q3m2cm6ZHa1dyH\neb6sRj3qhrqCR2MNwDa+XWXaavZjulYWAKvZDQhhtj4hZQ0+2tr8dpeXXKDpB3s8xw2rvueUOVKN\nGXp9FoaSs4Hf6L4qmVq1LnWHlvLhpkqioR6Xb/LBHhbsCo63+CP+wFs4u9K/0duxa4wqw1Yi3b2g\n4fAlDiz0Bfo+OMrYaVtudmzJm6JD0vYzr++zJf3OWC6H1YFt6PKHh3w8S9fWx9NuTlcxnSUL+8rQ\n3TrNoctLLOgc8UPsd3PvwRR0PbFI5BRikcgpxCKRU5t4LnMMgZxnkKEcmUI8E/t07j2QS6HqtEjk\nFGKRyCnEIpFTiEUipxCLRE4hFomcQiwSOYVYJHIKsUjkFGKRyCnEIpFTiEUipxCLRE4hFomcQiwS\nOYVYJHIKsUjkFGKRyCnEIpFTiEUipxCLRE4hFomcQiwSOYVYJHIKsUjkFGKRyCnEIpFTiEUipxCL\nRE4hFomcQiwSOYVYJHIKsUjkFGKRyCnEIpFTiEUipxCLRO7R3Dvw5vgJfovvTv6yj/F7a+Y+dpFd\nEYYY38dfrDr1i7JQhOU8qTotEjmFWCRy702ImRx6jG7rHrd9j8i5irFNvIEOeXczoLL6nmcVuD6w\nkYUtu235trVtgTlXFuY+OpGHRR9iC1jS8MxqgAUX9mL3OcxQ3R/IvsxlBofAW5S2ArBCjuXcRyfy\nsOhDDNAjtCWwLWks9/RcZ/b8wAYylAATeFsCDLhhacECA/19JbvI+biENnGKLrbMELATO3ocPjmU\nWA3AIacDrIKDBwBUyOY+NJGHHSnEzPBX3PIV/QmOwbfBZYocV3uqzWkfbBa84yve8o63LLr7EgQA\nsNpoof0i6NrFNU6x9yLv6CjVaTq8xI8AJLjBk6MfQ4qGBYDEnu193LUxZYbSllzYirmtu7kylBvP\nXoxawuqhlgg8YnqErf5y+PdP+Dm+nXzr/1r/Qg90fcu3XNjq/j+zsq1aM9moXrvxSCzmXbdWa1yq\nf3iUd+pt/AT/nnsX3tEH+GDy/4rTHwPwv7l3onWc6vQ/h1v/PfqHNbSI4dCdC6ZjCjDdc254YRWS\ndTg328vM0NiKyfB3KoklAo+OMwqZL/ASQMCL6bfPzV/90JXlseximaHkHZbIsXHCiX3M18HP1ueP\nmaKxGoC3cs/Lfnf68doir+NIHVu2wke4wpO9cZgMPQukSLqKbg3HDAGwFRJUVnXnjEv0FeEFKgBh\n3GHVd4QxwQ3uaDSsu7wUW4kAbe49ePNdToF9pSIdPBpr6AAs0FjZn+flTXuemK6NLJO2HcysbSnf\n8zr5eAQYC9PQDzlLFzDYo2ehKzkXcAASDqeWUDK1al3qDl1Z/mAwEw31kBhcUIh7tjNK2koWrLfP\nIB++xIGFBl1KHC5hxNZrsCV2e6od7j0hRQdd/iCRuMCSeL/dqvGhmTosQBGWSLwnJbHI5VKIRSIX\nY3X6A/yM776VN/W4P0Elcl7+D0GmdzTgzdwdAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE1LTAxLTEz\nVDEzOjIyOjM5KzA5OjAwUj++GAAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNS0wMS0xM1QxMzoyMjoz\nOSswOTowMCNiBqQAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 51,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fb8128>"
-       ]
-      }
-     ],
-     "prompt_number": 51
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U3 = gate_sequence_product(qc3.propagators())\n",
-      "U3"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.354-0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0\\\\(0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354+0.354j)\\\\0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j)\\\\(-0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\(0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0\\\\0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354+0.354j)\\\\0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j)\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 52,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 0.35355339-0.35355339j  0.00000000+0.j         -0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "  -0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.35355339+0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339-0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j         -0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j         -0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j]\n",
-        " [ 0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339+0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339-0.35355339j]\n",
-        " [-0.35355339-0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j         -0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.35355339-0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339+0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "  -0.35355339-0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j         -0.35355339+0.35355339j]\n",
-        " [ 0.00000000+0.j          0.35355339-0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j]]"
-       ]
-      }
-     ],
-     "prompt_number": 52
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "The transformation can either be only in terms of 2-qubit gates:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "qc4 = qc3.resolve_gates(\"CNOT\")\n",
-      "qc4.png"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAABUYAAACSCAQAAAAj39h0AAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAWb0lEQVR42u3dT6gs6VnH8d8jNxHiyFiTRSaO\ncKDGgIoyjHXdZHP9U2cRBxdZ1HWCcSd9ycKNoN0gohuxD1m4cBFuQ3ZCwimiMBBcnN5kk4DeYpyN\nC3WazCIkLibl6CC6elx09f/qPt3nVNXb3ef7CWHO7dOn6q1+337ep6re9y1zAXdhX9Zb+qDz3V74\nl0IfOU6ZfU/f6Xynb/gXQh83AByvR6ELgJP1I33dx13v1IahDxsn7js+6HqXtFoA2OUnQhcAAAAA\nDxfJKAAAAIIhGUWHLN79W4vWXonWXwG6RqsFgHYxZhSNsEj96sdSYy9q3zPU1c6N9Kaj+SxSMh2N\n6qX1beRl6KNr6DNK9WuS/qn7kbaoR6sNxf5B77W+kwt92/829JE+PB1NbW10UqB9o4MSP9Hv+aTB\nMoeYirms4cnEJKNohJcamOuxF5INrefP1t9hmca7OujZ1STLFKm0G+U+kjRSX51POGmepRpqrP+R\nlFpfg/rEB92i1QbzXvvTyCwNfZAPVCdTWxueFPhBB+1x2GQqqiBTMVePp9ntkYyiIZaonKZYPjC3\nfCMcZf505wYy5ZLFSnwgWalry7300kpLTj11s55SXXppqeRji3RtI89Dlwq0WgA4BowZRVNSVR25\nZSq11hFbotvOCmMvJEXqWyT5WJESSdJYWehDux+LlfnTxfU1L/V0epQIjlYLAMGRjKIpybQrt1R9\nXW7c2kxnHb0N7YW9bzf2wm4WF/otVilJXrh5OU0NqhF4RdW9t8gy+7G5vW/t7Km/PurQS13NRyue\n0pGcnz1bbX27DdtqEQbfMaB53KZHU1JNbCgp9sc1v42m3bZlyn1gPR9Z35dTtEyrt617S2PuWr6G\naJGeK5IU61qvt7CDeHMElefWO8EjOT97tdqt7TZgq0UYfMeANjxq7dkgL0v6KPThbXhNPwhdhLM5\nhgt9e/EPS6RqVvGN9Xy07Y88n978tHjtBmi0PLjb+tVEkKnl61VPWmixF/PEIbavtdBqf35e5oul\naRW/eIJHcp+Sdf/o2G0lmdu31W5ttyFb7V0cT1R+0sE+XtVbLUxiOt7v2BsdrFCwj5WeoTXNfqe6\naI8XDUeBi/tv4u4sbrgGJo/CzsfC6VoL8/Oxd4oUL72nkDZufvb8maXLnfXq2DzLNPHcYqnq6pev\nMbUwg9AivV39WPpXWvikklmZpxOYqn3Gp3ck52AlgB7SajfabdhWe9o6Sc5bmdXNd+w2Ha1i0Oh3\nqpP22PCM/bAnuD6xhqMaY0bRjGQ+ui7ReHrNyXpK1V8fG2mzbn85ZC3d7rRUE88lJQ0vhLGVl5ou\n6TP7b9OKmvCcqYW51q0fybnZu9XWttugrRZh8B0D2kAyinuzxIZKFVcpV6HIMpWSj3SlSXX2lM87\n8Z7GksrVCR6z61AW61ovzM21mCTS+pp1PtIr+qZeb2m5pSsNV+fOW6SeRnfdXMAjOSMHttradhu2\n1SIMH+mL+hO+Y0CTmMCEe/NCxdLEjUslmvhEskSxj6brLXphs2tNIy8lL2x+XcGWrhL6RK+sbX59\nkkg7x1DaB209M8dLu9K1zRe6t1RDPWtxb60dyTk5sNVutNtjaLUI5GO9y3cMaBLJKBrm5fSakMXK\nJOsprzrt3FIfL64mLd3OTHaOPYlPf/Fwz63Qcyv1X/op60k1iwghqNtabU27PftWCwBdIRlFS3yy\n+kBEz21oxWYStnvxdxuex2MVfaJLi/SHkv6GRPR40WoBoHuMGUVnfLCYsbwk2j560qLpzdHz4KW+\nq++ez/E8DA+91QJA+7gyig7V3brcNfvYS9GpIzBaLQC0iyujAAAACIZkFAAAAMFwmx539Sl9saNn\nbSz7ZOjDxol7I8CTS14LfdAAcMxIRnFH/o7eCV0G4FD+hdAlAACs4jY9AAAAgiEZBQAAQDAkowAA\nAAiGZBQAAADBkIwCAAAgGJJRAAAABEMyCgAAgGBIRgEAABAMySgAAACCIRkFAABAMCSjAAAACIZk\nFABwIiyueS2yKHS5cH/U7UP2KHQBAACwSP3qx1JjL2rfM9TV5qteWt9GXoY+AmxD3eI2JKMAgOC8\n1MBcj72QbGg9f7b+Dss03pKWjNTXIPQRYBvqFrfhNj0A4AhYonJ61cwH6lm68YbMx/V/6aVKS0KX\nH9tRt9iNZBQAcAxSVQmJZSq1djPXEk12/O1YWejiYwfqFjtxmx4AcAySaZJiqfq63Lhpm85SGBsq\nVaSJIpUqfCBJXtgwdPGxw551W1e71O1DQDIKADgGqSY2lBT745rfRiolyTLlPrCej6zvVyu/x/Ha\nq2631i51e/ZIRgEAwVkiTa9y2o31fLTtfZ5Pb+tavHZrlxnXR2vfut1au9Tt2WPMKAAgvPmoQkWK\nJckiSyVLa9af7PlY8VqKwtWz43VI3dbVLnV79khGAQDhJfNxg4nGkv26MhX2QpqvUVmxKqFResDW\nEdLedUvtPlQkowCAoCyxoVLF1ZI/hSLL9J8+Uqyxj6tVKfN5etLTWFKppQV/LNb4sH2iGwfWbU3t\nUrcPAWNGAQBBeaFiaWHzSyWaqLRoOsvaEi8kL2x2FW3kpeSFLS+dnikPfRSoc2Dd1tUudfsAkIwC\nAI6IlxpL1lckKbbFsj+5pT6WZgsD+fIUl7j+IZM4LrfVbW3tUrcPAMkoAODo+MaTyj23oRV1D420\nIQ+MPCXULdYxZhQAcBJ8oJrZ1xZNb+3ilFG3DxtXRgEAJ6Luhq2XrEN5Dqjbh4wrowAAAAiGZBQA\nAADBkIwCAAAgGJJRAAAABEMyCgAAgGBIRgEAABAMySgAAACCIRkFAABAMCSjAAAACIZkFAAAAMHw\nONBA7Bv6oPOdXviXQh83Tpk90Sc63+lL+mf/fugjPyb2x/p0gN1+6F8NfeTnz2L9JT0DHiKS0VA+\n8EHXu7Rh6IPGiXtb3+p8n5+T9P3QB35UPt197CB6dMMnRs+AB4lkFMC+PvJx17u00McMAGgZY0YB\nAAAQDMnoCbF41+8sWnslWn8FwMO0K3YQPU4bdYtzQDJ6BCyyYfW/viVb3zVUuWMjPS+rbaXTF7xU\nj6CD0A7rKukoD7VP9LgldhA9jhR1e/zq4ttxR7FjPXlpZcyoxcr0eZn+RSOfdHEYp81LDcz12AvJ\nhtbzZ5vvsUxj3xp0Zo3FMkUq7Ua5jySN1FeAqQ6nxiL1FOuJSePux0Q2fCypUv2uRSqUe3n/7e3c\nV6R+9WOpsRe17xnqaudGej6QLFIy/eS9tL6N2i75Obk9euyOHUSPw1isTL+tT1mqvL7NN4e6DcVS\npfN/jH1cvbLRP9THtxBRbLPE9WXeLyKHiMktJKPWV6qRpl/T51aEmPl5aixROQ1sPjC3vCYlyvzp\njg1kyiWLlfhAslLXlnvppZWWtB0wT51l6utKI/WVq2c9PTvVVMgiPddEuaSRUt3YoN3Uuqmuko7y\nfm6NHrtjB9HjAFXv9tf6WFLfJm33btRtGD62Qj/WK15K1re+nvp4mtotv2tHfOs8itWUuNws8zGf\nvDR+m96GivzS8+nH45cqWTZiD/MGY5lKbQQJS7T7CnPshaRIfYskHyvS9KbOWFnoQztulinVpede\nSl74M410HbpMd3atkQ+8kHziI11qx6CPZix3lepZuvGG7JZ0OFNusRIfea4rDS2SvFTZdrnPzM7o\ncWvsIHrszfqK/dJzfSz52J9qYm1HC+o2EC+n/5f8SpF6tW/aGt9CRLH7lXj2+/nJS+cxueFk1JLp\nGdjSB3SluKaTwqpkGmYsVV+XNWcu6SwM2dBe2Pt2Yy/sZpbmWzwdNeSFm5fTsFVdYC9Et76DRepr\nsPx5+1iF9e++xYDHMtTKdRMv9VTPW95pE10lHeV97Y4eO2MH0WN/FitdvfrvI02s3ba6Z93SM7Sq\nVM2oyVviW9godpcSS0FPXpq+TZ/VXMwdqK8TH4nXulQTG0qK/XHt76NpULFMuQ+s5yPr+2LkR6Z8\n5d29pVo44oHURyDTxlgYH9iLW0bV3Illeq5IP7Tfaen2WLJ+y9BLG1vm+d02t98+902DlCrSRJFK\nzQfuTLtKL6ZLiS53lNxNOcju6LE7dhA99tfTaOO1Kz1Xm9+wveqWnqFNlijR9CQkskylZkO5dsa3\nkFFsqcSrZV45edks8+LkJURMbjoZ/ZXNMTQ+sZ9r+zBOmyVS1RhurOej7e/0fHp2Y/HKGU60PE3M\n+tU4j6kTHf/YkTdV94jDf21+RxbpuSJJn9W1Xm9h+7H+veblXH8QvqvcMw2io7yTfaPHlthB9Nhf\nXe9W2s+2t0N6hrBsqOnn9PrsRNtzyfpKNNbt8S1AFNss8UqZj/rk5VHD+e4vzbd3Ic1vz79+NFc6\nXtMPQhehcrH082KIcaRq2QVLVPpEsnhjPYKeP7N0EUpWL71bponnFkvV3y03oTeOpB5e1s8EeP5y\nnd/Q/9r/VT8/mX86n2/hc7qY10RsX9NHjW//J/Vb81IvjuRlpY0ey5PlfzSZBu3oKN/Urx7JQJ83\n9F7oIkhaq4XN6LF/7DgoejxpryW15FW91WjL+YXa3u2zDUeL0+8ZLvTtRj+Rel20x/XZ87UJ/Nb4\ntv7uixZbyrYSH1bmA05eLG64BiaPmp0NaPFsMSdLpdnHYgkz6tetVGMyv3ieaCBZokilnuvSetLq\nrSGbBaVFmMoWN5Ut1cQLSUntzdn3qIdVVmoy+6RsOL993EJ7tUhvVz+W/pUWjiTSL8/LvziSnt7d\ndT3l4L2sBp+6rjJVMRtGv2JnGrSzo3xX7576glvNWquF9ejxFf3j3rHjkOjxnSa/FZ2cFv9IX2+y\n5Vg0W8ypzd7t9HuGjk4dj6s9bsQ3bV5L/KDFltJAmQ84eZHkE2u0BpqfTT/enMNljBjdwRIbKp1P\n8iqqER6FYhVSdTtAyudriPU0llQuDz+fdf0W61ovzM21GMDOZ79LXtNe01sHed+Bl9UYnlLP7rmp\nbduvm++YtVr/y13lWLLEekrV18YEsKWOcrlss9OAtDolSFiV+DC10eN7h8QOoscB8s1JHNZXSwsk\n7dUz5EvfKHqGYGrj25GrKfPSTfoQMbnhMaM+spvV9cssUeqXXR3O6fFCxdK4jEslmvhEsmmwqW7F\n+GKG92i6CJFVKY1li2DoE72ytvms1RGDJ88nVqyO87FIQ7XSXn1kuRIVra1iOtDz1ZLbUOO2Qokl\nypSqtNTHmnWVhY8sUja/FpvPk+EdaZDFulZkkqo1Uuko91YfPezt/WIH0eMwPrZe1d4rFrfXu+3T\nM/jyyh/0DA2qlpDPbHEFPFUiWapYcfX6zvjWdRTbLPFmmZdKfPvJS+cxuflF75/q2saz7t36SlnA\nen9ezqt8omRlPEc+DYPzgdSz3+y+SRSzsPFuPrBrG+qqSoxSDVeXemp0X2WbX2if2MhuNKhuJEZ6\nrom3sCpAtbf6NChR7KPZ6eh+aRAdZVPm7Wvf2EH0ONQzXVs6HwSTqd/OfY5NW3uGfJYe0zM0ycca\nr2YuPp7XQHWyvSu+qfMotlniujIf88lL44vee+mXiuxGf6U/sxtFfkmjvxu/0tLZiOdKN58Qu/uZ\nsTbkROB2/lSFru1av2k3ynR5uuMTPdcz9eyF3rKb6QL4ne259LFPLFamxG6WzrXz6U3G2jRoe3Cj\no7ynfWIH0eNwXvqlSrvRX+jP7UaJgvRuy7VL3Qa1Pb4daxTLZyN6a05edqWbHRxNK8+m98HqEG8c\nyiLF0wHEi9d8YMnG+KRIox3b4Bnfe/H8XK7E+aSrKzVb9r5+Zp7b0GoGJuzqKuko72fv2BE2erzW\nwRSmz+jvm9+oX7WxCvG+Nmv3COv2U/piB5OYXmt9D7faFt+ON4rdJSJ3dTStJKO4Ly/rKn/z3GTX\niEAvWUkOoR3aVXIKdV/7xo6w0cN/v+vP5TzU1e7R1e07eqf7TyaM+vh2zFHsCE9eKiSjAFp0WFfJ\nKRSA01Eb3446ih3byctM42NGAQAAgH2RjAIAACAYbtOHEuLRnG+EPmicuA8DtNqX9c3Qh31kPhnk\nsb6fDH3YD4HF9Ax4mEhGA/EvhC4BcCj/augSQPI/Cl0CtMUnomfAg8RtegAAAARDMgoAAIBgSEYB\nAAAQDMkoAAAAgiEZBQAAQDAkowAAAAiGZBQAAADBkIwCAAAgGJJRAAAABEMyCgAAgGBIRgEAABAM\nySgAAACCIRkFAABAMCSjAAAACIZkFAAAAMGQjAIAACAYklEAAAAEQzIKAACAYEhGAQAAEAzJKAAA\nAIIhGQUAAEAwJKMAAAAIhmQUAAAAwZCMAgAAIBiSUQAAAARDMgoAAIBgSEYBAAAQDMkoAAAAgiEZ\nBQAAQDAkowAAAAiGZBQAAADBkIwCAAAgGJJRAAAABEMyCgAAgGBIRgEAABAMySgAAACCIRkFAABA\nMI9CF+Bw9kRv66POd3uhP/VJ6GMHAAA4LyeYjOoT+paPu96pDUlFAQAAmsZtegAAAARDMgoAAIBg\nHkwyavGu31m09kq0/goAAACad4pjRldYpH71Y6mxF1veNdTVjo30fFBtK5mORvXS+jbyMvTRAQAA\nnLeTT0a91MBcj72QbGg9f7b5Hss03p5Yzq6BWqZIpd0o95GkkfoahD46AACA83byyahkicrpFVEf\nmFteM9M+86c7NpAplyxW4gPJSl1b7qWXVlqy7UorAAAAmnAOY0ZTVemnZSq1kT5aot2LMsVeSIrU\nt0jysSIlkqSxstCHBgAAcN5aSkYt09/pxt63pINjSKYJqKXq67Lmdnw6S1BtaC/sfbuxF3Zjw+q1\nWKUkeeHm5TShrcaNFuqi9AAAAA9YK7fpLdJz/bSkWNd6vfVjSDWxoaTYH9f+Ppqmm5Yp94H1fGR9\nX0xnypSvvLu3NFKUGfUAAACtemRpC1t9c57GxfZl/ajxrf9w8Q9LpGou/I31fLT9zzyf3rK3eOW2\nfbT8ZCXrV9OXppavsr7cyid1F5/Rf4Quwj29pJcabxX392oHZXpJ0set7+Vz+rfW93GoLj7dth3j\n53qYbtpfO17Vx0dT9uOMYKfcPkPHh4sO9tF0DvFyB2XeyiJdNHo8ZTu36Rdfif9uvYnNR4wqUrWW\nqEWWSpbWrC3a87HiRZK5Op7UMk18ZPH877gyCgAA0KpH7Tzl3Z7puaRSz5rfvq3+M5lPWUo0qNLL\nTLm90EB9rSz0ZLN0dZHAZov1Ry3VxAtJiec1u/2onU8KaBwttR18rjhmtM876+S+Z8M5RNh7tV7a\nB80eT0sTmHykV3Sp12vTusZYYkOliqtKKRRZplLykWKNfVytOZprVmk9jSWVyxOTZhOeLNa1Xpib\nazG1iS83AABAq1pbZ9TL9lM5L1QsTTe6VKKJTyyyaDqDfrpOqBc2e0bTyEvJC6uul1q2WAjKJ3pl\nbfPrU5sAAADQsDNY9H5mnv72FEmKbb6kk3JLfby4CjqfspT4rmcsxSx5DwAA0K4zSkZnfOMp9J7b\n0Ir1FUht5/QkG/IwUAAAgLadYTJaxweWbDybKdLWhaAsmt7SBwAAZ+3D2WNwWnRhsU/uv5ml7bVf\n5l0+bHZzDyQZlTZvue9qFl6KVBQAgLPnXw1dgjuU+UuhS9Csc3g2PQAAAE4UySgAAACCOcXb9C/p\nc3b/rRzqwiJGkQIAADTr/wE8GG4VSyEd5AAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxNS0wMS0xM1Qx\nMzoyMjo0MCswOTowMM1i8tIAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTUtMDEtMTNUMTM6MjI6NDAr\nMDk6MDC8P0puAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
-       "prompt_number": 53,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fae7f0>"
-       ]
-      }
-     ],
-     "prompt_number": 53
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U4 = gate_sequence_product(qc4.propagators())\n",
-      "U4"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.354-0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0\\\\(0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354+0.354j)\\\\0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j)\\\\(-0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\(0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0\\\\0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354+0.354j)\\\\0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j)\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 54,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 0.35355339-0.35355339j  0.00000000+0.j         -0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "  -0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.35355339+0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339-0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j         -0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j         -0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j]\n",
-        " [ 0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339+0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339-0.35355339j]\n",
-        " [-0.35355339-0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j         -0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.35355339-0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339+0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "  -0.35355339-0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j         -0.35355339+0.35355339j]\n",
-        " [ 0.00000000+0.j          0.35355339-0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j]]"
-       ]
-      }
-     ],
-     "prompt_number": 54
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "qc5 = qc3.resolve_gates(\"ISWAP\")\n",
-      "qc5.png"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAABOMAAACTCAQAAABmfBWEAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAUhklEQVR42u3dv4vkeHrH8c9jxo4ODm0yCxc0\naLl4ODT5OtAG5sDgQIMX7LQG48yJ6k+oxnCpmYKLbo3NCLOwsDhoJRsdmNFxGy8rboKFu8CnWzgc\nbPI4kEpVXaWu7qpWlUrq96tYprZ+SHr6W4/qqa++X8lcAAAAGJ+/GHoDAADA2Njiaazz0lHGAQAA\njBJlHAAAwChRxgEAgJOzcP+zFmw9Emw/gl3P+l2c/YfeDxrP//q/Drp+AACeHAuUNncr5V50vGKh\n672LmPm8WVLkuSR5ZaktvTrZNn+sv9f3Z/9TXfmnfS6u5zJO7+tmGArDHwEAODevNDfXSy8kW9jM\nX99+3hLl+wqyVb+bJQpU2Y0yX0paKtXpqoq/1H/VBeM59V2n9F3GAQCAJ8ciVXUvnM/NLdsqkBJ/\ntfftiTLJQkU+l6zSW8u88soqi7r69rDC2DgAAPBYsZrCzRJVulV6WaTynneHXkgKlFogea5AkSQp\nVzJ0YJeN3jgAAPBYUV26WaxUn2wdQI3XZZ0tFCtQqUCVimY8XKhKkryQSXUh2IyPKxgstR9lHAAA\neKxYpS0khf5y57lATVlniTKf28yXlvp6ykOi7NbrZxsj4pitutczi3td3vOB47nqOZ5j/UjSn4fe\niB59qN8PvQnE9SSi+am+GXoTejSt/cAUovlQf55ADJeS57e+7y2Smp61G5v58q43eVYfYrXw1mHW\nwDf+z9JmgkNts1/vea/f8T8bZH/z437rFMbGAQCAx2lHxilQc344i+8489vMc4Xr8uz2yDlLVPrS\nwvYsc/TG7fWs38m2g/eFvT//5GEAvSF/gZHY+r6P2tFvkeaSRYoUKpa2TxhiqzJvXfgl6zPKWazS\nC0mRZx0r/UOf3/E2zB/u+37rFHrjAADA0SyyhWKFTWFXKLBElS91rbI5l2ymddE3Uy6pamaiSpJW\nEyIs1Fu9MzfXon2EH3d7McUBAAAczQsVG31unyhS6aVFCn1Zn/XNC0vb55deSV5Yc4JgS9azWL3U\nB1sL3578gC30xgEAgJ545bmXFipRZDdtn1u2Ogi76nlrJzV0Hz5dCTn57370xgEAgF55eXtMnGe2\nsGL3cly2dwKDLU54Ka6JoDcOAACcmM9XM1hvCXTnyUksqA/AYh964wAAwMl1HR71PRfp8koUcfei\nNw4AAGCUKOMAAABGiYOqAADgUENc/PJq6KAvD71xAADgUF8+kXVeOHrjAADAgfyzobcAEr1xAAAA\nI0UZBwAAMEqUcQAAAKNEGQcAADBKlHEAAACjRBkHAAAwSpRxAAAAo0QZBwAAMEqUcQAAAKNEGQcA\nADBKlHEAAACjRBkHAAAwSpRxAAAAo/Rs6A0AAAC4JBYoUahKS8UKFEqSz222uifZYnVPskixXzfv\njBW3i8k9P/WWUsYBAABIskhv/KWkheZe1cWaz22h2F9KvrRUqX8gSbrWG71u3pYoUVPGeW6F/qgP\nvJIstVSvvDrlFnNQFQAAQJIX/lKySGFTfNXFWabIAklSrsAiSfJK2UaBFtaPNs+ofsavFWh22i2m\njAMAANjUlG1eKZe8UKmkflx5fc8SNQdMLVKmrHl+W6XgtBtKGQcAAJ48Cyy1NxZJXijXt/bWUgub\n0W1ZM+ItUL4a+9b2xcVeKO/qdbNIkZan3WrKOAAAgMSvFdS9Z/5K15JSvWsOlmZKLLBApTJFFt56\nXyD5UrKN/jhb2MJSxfrIy9NuNFMcAAAAMgsUreaW1jNP7Y1SvZK8sFKJKs8kK5RY2R5STVRaLKlQ\nrKxd1hnmqNbojQMAAE+eV0rqQsxiW500ZK7V1IWsPZFIpkRBe0g18qXnnmt5x+i4E6OMAwAAkBIt\nm0Oj63O/Fc2/60kMWVvaSVJTznl2+7DquXBQFQAAQFJboAWWqpA2zgdXWOGZJHlpRX1I1WLNFFrh\nuWQLVUotaqZAJKbzHFaljAMAAJB/YqGXkgoVXlks+euNp1+t79UTFzxXW6r5XPPmbt7eOwPKOAAA\nAElNeVafvDfveu72veExNg4AAGCUKOMAAABGiTIOAABglCjjAAAARokyDgAAYJQo4wAAAEaJMg4A\nAGCUKOMAAABGiTIOAABglCjjAAAARokyDgAAYJQo4wAAAEbp2dAbgNOyX+iHobeh8cL/ZuhNAB7K\nfq2vht6GRq+ZY3+rv9MfzhzBc/2P/9uZ13nh7L/19dlXeqUv/bOhI0ffKOOm7gefD70JNVsMvQXA\nAb6aaOb8n/7d8zNHEJ93faPw9fk/X7TDNHFQFQAAYJQo4wAAAEbpQso4C/c/a8HWI8H2I+jP/tbo\nfgctBEw1c9g/XwbaAV1OOjbOYq2Pxef1eAyLFa/ut69b6HrvgmbrUQQWeil5ZaktvTrtH8d+pe9O\nu4ZOP/F/PFlEgdLmbqXci87X3NcaXZoWskBR3bbnaSFcpkGGbz/X5/7FySKaaOb0EhfZ/2i0A453\n0jLOcyv0R33glWSppXrlled1Ibd+lSXK933Qtn5PvLW555KWSnXqIaLfDTHI+ZRTAbzS3FwvvZBs\nYTN/vbP2e1qjc4uD9r2BKrtR5kudp4VwmSY3fHuqmfP4uIaPYQpoBxzvxAdVvar/k/xagWadL0ru\nmTeVKFvdtdnGkiuLzveHmgqLVNW/9XyuWcdX332t0SVRJlmoyJee6VoLC2ghTMtUM+fRcV1ADFNA\nO+BY5xwbV6njOL1FKu95X7jqYrZQpda/R3IlZ9z6qWh7Qi1Rpa3O+we0Rpe6hQKlFkieK1C946CF\nMB1TzZzHxnUJMUwB7YAjna2Ms0iRls3/BJZYbG8tkBSvP7C2sHf2rd3YO7tZHVq0cKNwizZ/j3gh\nfmUcLqr/3hYr1Sc7nfSxin1v3tdCXrh5Ve+EmpEZtBCmY6qZ88C4uiK4mBimgHbAkc5w+l9bSKok\nfbT+aHomWapIuYJVmWaJMp/bzJeW+nooZ3tI1RJtdyozC+dwsUpbSAr9ZcezgfaNvrinhRqzjbEY\ntBCmYqqZ86C47ojgUmKYAtoBR3rW84D6Fx2P5TvH9Dt3eJ7VXccW3uo+DryU6l8bO79Qdpfzca/x\nfNzr3+ahXpwuBoukZjbTjc18effbbKbbk9tzz/e3UPO+tBlaW9tsoasLvI7Dld4PvQmTjOZqgHV+\nqJ/3Os3h1r5s0Mzpd49wpS8Pj+uOCB4aQ99t85jo/6Tvh94ISUfumSfTDj8Z5CwQu25lw/nW2u93\n4bN+Z5Q9euNm/tri9cduY0RArNBiSZESU1MY7v7K6PUCOgOVHb3O8tuKYT1HOFh92VisYjURZe3O\nHcndLSTJEpWeWSg1O5XNFnp/KRc3wqkNkjm/1y/7vMjUfZljkSovV6dAWjtB5vS7R7j9Nd6xR7hr\nn7AdwQEx9Nw2U3Ds50u0Q48GKmp7/i68kNP/1my1I1n/aduuYl/63Oc+V6CMD+LRonYET6Rcsshm\nipW25yy6x74WkixW6ZmkyI8Z7g1cru3M+SdJbySb6UFfBBebOTt7hCamnX1CRwSXEsMUPPjzRTtg\n20nLOIttISnZrHgtVqTIYpspVGKxso2P40y5pGpzSObmL0ILN5dnoSjnDmCRLdo+TalQYIkqX+pa\nZfvbILvnS2lPC1mot3pnbq71EG5aCKPXmTm/VqhCzZeuRpk53XsE6dY+YR1XRwTDxzAFB36+aAds\n815vWhzxnrftvaD5N2z+TZTseV+qqI/19xvNpa31rqUpUKzQpUiJa/2XXLdG97uOb6Fh/prchrgN\n0daKFZ8jhjZzFopdumkfH0nm3PV3WsW1vU9YxbUdwSEx9N02U7gd+/miHXpthUH+In3vHy/hoGq2\n6q1b/aJoO4Mjz/a8L/S9U/yxj1eee2mhEkV2s/HLLts3WoAWwlNXZ46kUpHNNsYkjTxzVnHt7BOa\nuHYiuMAYpuC+zxftgG1nOOHIfTyzhRW7lxnZf1FfW3CJkcfzcvuveFdrdKGF8JT5tS3WB6ymkjnb\n+wT2z0N52OeLdniUH+mndv619jyT/xJ64+TzrSn6tUB3Tru2QFzw90TuaI0utBCeKAsU1jMC149N\nNXPYP5/fAZ8v2uExfqtvBlhrzyc5uYDeOEnq6vbdN8/GK/HhPJmHdsLTQniqvOrq5Zhq5rB/PreH\nf75oh8fw3+l3Q2/D411EbxwAAAAORRkHAAAwShdyUBUnczmXwBrm0mbAca4u5LJF0vNelzbEBZmu\n9BvOXrbl+QCfr58NMhIMJ0YZN3H+6dBbAIzSENda7PZ5nwvzz/TZ0AFBPbfqA32j3w4dNvpHGQcA\nO5xiByfkXwy9BZgKxsYBAACMEmUcAADAKFHGAQAAjBJlHAAAwChRxgEAAIwSZRwAAMAoUcYBAACM\nEmUcAADAKFHGAQAAjBJlHAAAwChRxgEAAIwSZRwAAMAoPRt6A8bJAiUKVWmp2DObKZQkn6/vSbZY\n3ZMsUuzXzXtjxe2Ccs+HjgU4n8MyZzNvyBwA6OC93rTod3nDrr9raYr0zqU3CupX1K/RQu+a51P9\nsbkX6G39KpcW+nZjGYG8eX+qm9VrLuVvyI3bY2+7n+E6bw7NnNt5sz9zFCseOm5u3LhxO/eNg6oH\n8sJfWqTQK0nSqqcgU2SBJClXYJEkeaWseZUkhfWjzTOqn/FrBZoNHRNwal74S+mIzNnIGzIHALZR\nxh2n+erxSrkkeaFSSf2M8vqeJWoO+1ikTFnz/LZKwdDBAGdzQObszRsyBwBEGXcQCyy1NxZ5oVzf\n2ltLLWxH6GTNuJ1A+WoET9ujEHuhvKvvwCJFWg4dF3BKq7yRDsycO/OGzAGAGmXcIRK/VqBA8le6\nlpTqXXvIJ1NigQUqlSmy8Nb7AsmXkm30K9jCFpYq1kdeDh0WcFJt3hyYOR15Q+YAwCZmqh4is0BR\n3YtQz5+zN0r1SpK8sFKJKs8kK5RY2R5STVRaLKlQrKxdFjPt8FRs5M3DM+eOvCFzAGADvXEH8EqJ\nMsliW534YK71AOysPR1CpkRBe0g18qXnnmt55ygfYMJWeXNg5pA3AHAvyrjDJFpaIm2cv6po760H\nY2cbX1FSU855tn14CHgiVnlzSOaQNwBwLw6qHqr+mgksVSEpaU+cIC+s8EySvLSiOTAUa6bQCs8l\nW6hSalEzkDsxcXAIT8aqPHtQ5nTljc+b0/+SOQDQMu93cYv6qgWDhdPr+ruWZqGXFkheWaytrxML\nV4Ou1/eGjgE4v93PcJ0Rp8yc3aUCwPTRG3cgL9sTkOZdz23fA7DKCDIHAPrF2DgAAIBRoowDAAAY\nJco4AACAUaKMAwAAGCXKOAAAgFGijAMAABglyjgAAIBRoowDAAAYJco4AACAUaKMAwAAGCXKOAAA\ngFGijAMAABglyjgAAIBRejb0BgDHsH/Qz/V+6K1oXPmnPUb2C/1w9ghe6J+9PPtagaPYr/TdAKv9\nK/+XoSMHdlHGYZx+r196PvRG1GzR6+J+8Pn5I6CIw4h8d/4c6T3PgZ5wUBUAAGCUKOMAAABGiTIO\nT4aFx7zHgq1Hgu1HhrcvsnFEAJzW/uwnSzBejI3DBFigtLlbKfei8zULXR+x6Fk9CscCRfVYPK8s\ntaVXo4ls4AiA0+ol+8kSjBZlHCbAK83N9dILyRY289fbr7BE+eG75NXvcUsUqLIbZb6UtFSqMw2x\nfmxkw0cAnNbjs58swZhRxmESLFJV/w73ubllO7NYE391xGITZZKFinwuWaW3lnnllVUWdf/qv7jI\nLiAC4LQenf1kCUaMsXGYhljNrtsSVdra9Vqk406oEXohKVBqgeS5AkWSpFzJSCK7hAiA03ps9pMl\nGDF64zANUb3ztlipPtk5gBLrnt/UtlCsQKUCVSqacTKhKknyQibVXxHNuJnijOeQemBkFxwBcFqP\nyBGyBGNHGYdpiFXaQlLoLzueDbR3XJwlynxuM19a6uuh0ImyWy+bbYyUOd8stgdFdtERAKf1mBwh\nSzByz3r+tfFi4Hg+7jWejweJ4cUF/gK8upgLX6236DdqR8BYJDX9Tzc28+W+N9pMt089kHvuWX3o\nxcJbh1+CzWsbWNoMfK5tloUn/NQ9NLJHRnDV82fuqtelPcyH+rnFA6x3nx9L+n7ojZhgNLe+Zx6Z\nI0Pl+fEub298uJ8Mcjm1fr3Q10NvQu1Zvxc1Gfxj/lWf8QwUzddDXGhmbLa+sNuxMQpWRZpFqryU\nLLx9oak7d/Mzf23xerd9e0SNJSo9s1Bqlrb5K/2Un7quyGIVUsfMu+MjeD+B/cAFXZ4Np3VfjtSn\nDbFY5c5F5rZyZLg8B/rCFAdMQdSOfYuUSxZZLOmNZDM9qIfGVkXS+tUbh1osVumZpOjs1x7djWym\nWGl7pqzLjwA4re0c+WslKuydtJ0lHTlClmD0KOMwchbZQrHCpn+uUNDMVgtVqNmxK7u3mJspl1Q1\nM9Qkrfu7LNRbvTM316J95Az9Pt2R+VLXKtt+gXVkFxgBcFqdOfInXypU7nlzBrm9OUKWYOyY4oCR\n80LFxpDkTxTVh1KsLuBCLyUvLL1nMUuvJC+sOXWoJeu5rV7qg61Xbw+KPmNkFin05ep8VhuRXWAE\nwGl15YgqC+rZqXWW3J0jZAmmgN44TIpXnjcHREpFNmvHvWT7h7+vfpG3B1Mi37cDD89/UtA6MguV\nKLKbjf6EJrLLjwA4rSb7Z0oVKLR4O/t3coQswQT03Rt3NfBcsR/3urTng0TzfIB1TpJf22J1UMQz\nW1jx0Mtx7b8oti2Gu0SPl9vr7o5s4AiG2A/8TN+cfZ24QL5z9dS7sv9y8xx4uL57474cOJ7/7HVp\nnw8SwzBrnRgLFNazzlaP+HzrRCP7BLrztAUW6MIumN0Z2bARDLEf+Ea/HWCtGIU7sn9UeQ5067k3\nzj8bOqBeo/li6C3Asbza/SX98AMk++apeaWL27nvRjZsBNPaD2AKurJ/bHkOdGFsHAAAwChRxgEA\nAIwSJxzBOP1IP7Wht2Gl34k1fV8Y6yE+3r7WBXDBhrlg4RCXmAPu9f969/JTl3/bPwAAACV0RVh0\nZGF0ZTpjcmVhdGUAMjAxNS0wMS0xM1QxMzoyMjo0MSswOTowMGsV+WYAAAAldEVYdGRhdGU6bW9k\naWZ5ADIwMTUtMDEtMTNUMTM6MjI6NDErMDk6MDAaSEHaAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYt\nMS41IAVcCzkAAAAASUVORK5CYII=\n",
-       "prompt_number": 55,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fb8ba8>"
-       ]
-      }
-     ],
-     "prompt_number": 55
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U5 = gate_sequence_product(qc5.propagators())\n",
-      "U5"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.354-0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0\\\\(0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354+0.354j)\\\\0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j)\\\\(-0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\(0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0\\\\0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354+0.354j)\\\\0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j)\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 56,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 0.35355339-0.35355339j  0.00000000+0.j         -0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "  -0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.35355339+0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339-0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j         -0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j         -0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j]\n",
-        " [ 0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339+0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339-0.35355339j]\n",
-        " [-0.35355339-0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j         -0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.35355339-0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339+0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "  -0.35355339-0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j         -0.35355339+0.35355339j]\n",
-        " [ 0.00000000+0.j          0.35355339-0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j]]"
-       ]
-      }
-     ],
-     "prompt_number": 56
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Or the transformation can be in terms of any 2 single qubit rotation gates along with the 2-qubit gate."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "qc6 = qc3.resolve_gates([\"ISWAP\", \"RX\", \"RY\"])\n",
-      "qc6.png"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAACCEAAACTCAQAAAAQLFnfAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAZz0lEQVR42u3dvasj2ZnH8d+z9DpaaNckMzDB\nhTIbN3Z1MlE7qAnMgMFBNWt2napx6kT6E3QTZ8vSAkc7xqYrGBgYHEwlHQ2Yrh13bCzcwYCduOzE\nwSTPBlV6f7mlq3qT7vdzMSPrXpXq10c6p/SozilzAQAAAMBDZ7/T2773ofLEf9Rosq/0uvMMz/yj\nBhP8WD/RXzvP0HA7XIdHfe8AAAAAAAzAW5/0vQslmza8wdfdJ2s4wz/1a88uPMOV+Je+dwAAAAAA\nAFwCSggAAAAAAKAGSggAAAAAcC8Wnv4IC7buCbbv6d/xXJeR4XiKS8kwPA2vhdD7EiTf8V/0+vwA\nAAAALp4FGlc3C2WeH/irqW5P3vSoXJfAAkXl7H4vbGwzL4aT7M5cF5DhzhSdZ7BQ/93Dp+X39Zl/\n3uQGm15OseclSFjwAgAAAMC5vNDEXE89l2xqI3+x+zeWKDv1A+fie25LFKiwL5X6TNJMY3X0Oeru\nZHfluoQMd6XoI4PPrYdPyxY3vUWuyAAAAAAAWyxSUX6/7RNzS/dcDyDx5ydvNlEqWajIJ5IVemWp\nF15YYdGhb9M7T3ZXrkvIcFeKAWS4VKyFAAAAAADbYlUfSy1RoZ2PlRZpfo+thp5LCjS2QPJMgSJJ\nUqZkGMlq5Bp8hhophpDhQnEWAgAAAABsi8oPphZrrI/3nBIf6+i31TZVrEBzBSqUV/PuQxWS5LlM\nKj/+VvPw8w6nZB9PtpbrYjOspRhwhgtFCQEAAAAAtsWa21RS6E/3/j7QsfUCEqU+sZHPbOyrRf0S\npRt/Nlqbed/d1QCOJ1vmuuAMyxSDznChHjVcZXnSc55nA6kaPZb0j753okEf6pu+d6ElN3rX9y40\n6EnPV0Rp1rW9i1au61X3WN+9+DzX8Vq7rtcVo85luIZR5xoyXMOrajgZblY3LZKqb6y/tJHPjj3M\nRtq8eGDmmaflyfQWbpxQH/ja/7NxtYhfab0gcdPwp5p7JTszw5NGM9zoix4ytNgOnfm+ftDokorZ\no2bXhOz9A/zrfq8IAQAAAOAybXyWWc61V7AoEJSX/7NYc9+YZ3/wI+zIX1i8+ki6OT/fEs09tVCq\ntrb+7fe7Fj+l7UsWqfC5ZKFvryBw/wyNXn1g60PwCa1zVoY226ErX+vrPYtNnoHlFAEAAABgU7Rc\nESBSJllkgRLl9kbSuM4GbPHhdvXhd+30eYs191RS5PdZlLHZZLGkl5KNtPVt9QVlONg6g81wsSgh\nAAAAAMCSRTZVrLD65jtXYIkKyWcKlXnmLyRJqY6fHj5SJqmoVvqXJC2W/bNQr/TG3FzT5T2NflN8\nUrJcoXJVH8c3cl1OhsOtM8AMl43lFAEAAABgyXPla8vrfaxIc59bYEG5zr9Fnkue2/GzEWZeSJ5b\n+ZFWlqyudOBzvbf119sL/HWYTLKyeBD6fCvXxWQ40joDzHDZKCEAAAAAwAFeVN9LjxRICm110cPU\n4sOzzBffdC9PkI+OzqsP/eglIltNJs0VrS04uMx1QRkOts7wM1waSggAAAAAcIe1SwIu7kltarkX\ndR5tRy8VaFP1vCi839p0UVA4lGvIGeq2zpAzXArWQgAAAACAe/DJ1uUcDwt08NKDFpQn2/fFAoXl\ndQnuyDXgDPvsTXFhGYaIsxAAAAAA4F7qnvZ+bL1/L9TrB1cvdr9735dryBkO7NVOisvLMDychQAA\nAAAAAGqghAAAAAAAAGpgIgMAAAAASM9s2vcuLPak4e3dWNx5hptGt/aBPukhQ9PtcBUoIQAAAACA\n/KO+96A1X1z6c/qn+rSHDNiDEgIAAAAAXDHn4zcaw1oIAAAAAACgBkoIAAAAAACgBkoIAAAAAACg\nBkoIAAAAAACgBkoIAAAAAACgBkoIAAAAAACgBkoIAAAAAACgBkoIAAAAAACgBkoIAAAAAACgBkoI\nAAAAAACgBkoIAAAAAACgBkoIAAAAAACghkd97wAAAAAAAA+XBUoUqtBMsQKFkuQTGy1uSTZd3JIs\nUuy3y8fGipcbyjxre18pIQAAAAAA0DmL9NKfSppq4kVZKPCJTRX7U8lnNtbY35Mk3eqlXlQPS5Ro\nWULwzHL9Te95IdnYxnruRZv7zEQGAAAAAAA657k/lSxSWH3sLwsDqSILJEmZAoskyQula6WBsLy3\n2kpR/k/yWwUatbvPlBAAAAAAAOhPVTLwQpnkueZKyvuVlbcsUTVFwSKlSqvf7yoUtLurlBAAAAAA\nAOiUBTa2lxZJnivTn+yVjS2s1jJIq/UNAmWLlQ6W5yDEnivbf66BRYo0a3e/KSEAAAAAANCtxG8V\nlOcM+HPdShrrTTVBIVVigQWaK1Vk4cbjAslnkm2ch2BTm9pYsb7n83Z3m+UUAQAAAADoVmqBosUV\nFMorLNhLjfVc8tzmSlR4KlmuxObLaQyJ5hZLyhUrXdtaB9diKHEWAgAAAAAAnfJCSVkEsNgWl2Wc\naLFMYrq8VGOqRMFyGkPkM8880+zgaggto4QAAAAAAEDXEs2q6Qjx8r68+u9qwcRUa1dfUFVK8HR7\nKkNXmMgAAAAAAED3FsWBwMbKJSXVZR3lueWeSpLPLS+nMViskULLPZNsqkJji3xisWJJiambqQzm\nzW5u6pMudnuozw8AAAAAwK7dT6sW+lyyQPLCYm0UAcrfbd66x3NubfV8nIUAAAAAAEDnytJAuc7B\n9gf9Vdmg7WssnIa1EAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2U\nEAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2UEAAA\nAAAAQA2UEAAAAAAAQA2P+t4BtMt+qW/73oel7/gvGkz2G73rO1DlRl/4pw0m+53edp7hfX3mn3f+\nrACujv2XPhlO7+w/bTDZ/+qbvgNVGu6x7Su97jzDM/2nzxvMwMg5CL20Q8NHYQDuRgnh2n3rk753\nYcGmjW7u3VCSWdzwBt92n6zxDAAeqr/oV571vROlhkedb6521Hndw6gzbbKAIEbOoaAdgAeBiQwA\nAAAAAKAGSggAAAAAAKCGgZQQLDz+Wwu27gm270FzjrfGocdcQhs1kWyIuU59Bw0zA4CHilHnupJd\nRgJGzqGgHYDL0+paCBZrNT8pK+dGWqx4cXv5d1PdHt3QaDWzykKfS17Y2GZetPuP09PSSR/6z1pL\nFGhc3SyUeb73b+5qjf2qNrJAUdm63bRRV8mGnKv+O2iRotsMAOrqaQFcRh2SNZvsAhIwcnahkXdJ\nr0dhAPZrtYTgmeX6m97zQrKxjfXcC8/KIsLqryxRdqwr2Ko2vrKJZ5JmGqvtJVt6WTqp4eWfNnih\nibmeei7Z1Eb+YufZ72iNA/scLB8dqLAvlfpM3bRRJ8mGnKv+O2gjRYcZANTWywK4jDokazLZJSRg\n5OzG+e+Svo/CAOzX8hUZvDCVXYPfWqLR3kpj4s+PbiRRurhpo7UtFxYdqi3jEItUlP9qPjG3dGfd\n7LtaY79EqWShIp9IVuiVpV5020btJRt4rprvoO0UvH8AdIFR58Elu4QEjJwdOftd0vtRGIB9ulwL\nodCe2UsW6a7L+oSLbsJCzbWqVWZKOtz7a7E8A8QSFdrqgGu0xn5lGwUaWyB5pkCRpG7bqL1kA851\nwjtoOwXvHwBdYNR5aMkGn4CRs0Pnvkv6PwoDsEfLZyGsWKRIixOYAktUaKQXXihedSg2VaxAcwUq\nlFdz0MK1okHkqS1mVcnzNk++vFpR+e9tscb6eOfksVh3VHWPtZHnMqkcJqoZa1220VnJ9uVaJBt0\nrrVkxzLspuD9A6ATrfXNA++dH0Cyiz0iYOTszhmvpYEchQHYo4MSgk0lFZK+t+o6PJVsrEiZgkWJ\nwBKlPrGRz2zsqwkPy2kMlmj79CfWZD1drLlNJYX+dM9vAx2dt3lXG1VGa3PUumujM5IdyLWdbIi5\nlslqZlhPwfsHQPva75uH2TtffbILPiJg5OzOOa+lYRyFAdjjUcN1vCd77st2Zj7tHVY9LU9psnDj\ntKbA51JZidypXu5u51mjeZ41+m9T15P2MlgkVd8TfGkjnx17oI20eZmdzLPjbVQ9blwtd1Nab6MW\nW6d+shNybSQ7kuv7+oHFas7NfXLVybCVYj3DB/qk0QxNeCzpH33vRCtu9K7vXWjQY3334vMM57V2\nDaPOjb5Y/Z8zR53T+7W1ns3ChkedjSOcPpM13mPfK9mZRwQ3DR9/PuyRczijSpOvpb6OwpownFGl\nGU/0tu9duKIMN+dv4mRNv0uyR82u/nz2gDDyFxavHQCsZknFCi2WFCkxVUWJ3Rrk6ybz9HSa1NsW\nM6yuhRGUBzTlZXIs1ty35qMd7OoPt5EkSzT31EKp2t56G7XZOrvJIhU+X1wG9PRcm8mO5vpaX+9Z\nqqmZZDu5jrXZ8Qw7KdYz/EW/ajIDgPu4ilFn8yBlXx92Wu98Wr+21rP53LoddU4dT++drOke+77j\nqc45InjX4vEnI2dvmnst9XcUBrSrl5G+8XdJl8sp3skWXf3qAGR5CpPPfOITnyhQSkdxb9Fybmak\nTLIfKlFub6TllXvvcKyNJIs191RS5PdbRqq5ZD+X9FKykWrV3PbkWp9EM5xckQWH2ux4hl5TAHio\ndvuwWCf0zgPu184cTy8o2cHx9GKOCBg5+3LOa2kYR2EA9mq1hGCxTSUl699JWKxIkcU2UqjEYqVr\n3cVImaSiWm9VkrQ+ecHC9e1ZKEoJJ7DIpstzOaRcgSX6u88UKvOsulZveuch3ZE2slCv9MbcXNPl\nPR200d5kXylUrmrQqpFsT65FskHlKqSDbXYkw24K3j8A2nWgD8s3eucz+uaB9c6njqeXk+zweHop\nRwSMnD04/7XU91EYgCO80R9N7/GYV8tbQfXfsPpvouTI48aKmnj+ZtMM7VkPbU2BYoUKFGisxLX4\nt1y1xqHH3b+Nukzm0lSxS1/uvs7q5DqebCtXrLj9ZMtcB9tsSBn44Yef+/xcxahzoDdZ9GHbvXOT\nfXOfo86p4+k5yboZde4eT4dzRMDIOZSfpl5LtAM/1/vTx0jf/LtkCBMZ0sVZCouq7/I0pcjTI48r\nr9mLe/HCM59rpLEChRYv55ulxxfbGH4bVcmkuSIbrc1nPJpsJ9fxZH3mOthmw88A4OFa9mHbvXOT\nfXOfvfOJ4+kFJTs4nl7QEQEjZ89Ofi3RDsCgdXBRx7t4alPLd6/aa0cv2GJTNboQz8O0cemc8p4D\nrbHfsNvIb226OtWtuWT95qrfZsPNAOBhW++dr2XUYTwdcgJGzuGod2xGO+BaWaCbHq4g8n39sdkN\nDuEsBPlk63JHpUAHL/9igWZ1h2Wc5kBr7DfYNrJAYbl+b9PJhvjaO/UdNMQMAB6G3d75Okadfa4j\nWe3xdLAJ9mPk7N4Jx2a0A67XF+dv4mR/1B+a3eAAzkKQpH0nJB1bddUL0X20pv7pYcNtIy/21aib\nSDbM195p76BhZgDwEOzrna9h1DmwT1eQrO54OtwEB/eKkbNj9Y/NaAdcKy/0ad/70IRBnIUAAAAA\nAACGjhICAAAAAACoYSATGdCaG5v2vQurfWl0a497WIxkv6aXKHnWQ5vd9DIzC8D1+Tf9u/W9DwuP\nG93ak8GMp0332H0s7nVjQaMz2hk5h+H9a1goDsBdKCFcOf9p33vQmt/qX/vehUrDS5T4R30HAoB7\n+0PfO7Dmt01uzH/Ud5zW9PFBuOHnZOQciM96eM7GF4oDcBdKCLhQ/rrvPQAAbPM/68997wNO41ex\nuBeGwD/vew8AdIG1EAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2U\nEAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2UEAAAAAAAQA2UEAAA\nAAAAQA2P+t6By2SBEoUqNFPsqY0USpJPVrckmy5uSRYp9tvqsbHi5YYyz/rOAgAYOkYdAAAwDJQQ\nTmSRXvpTTTXxojpgS31mU8X+VPKZjTX29yRJt3qpF9XDEiWqDuY8s1x/03teSDa2sZ570XcqAMAw\nMeoAAIAhYSLDiTz3pxYprA7AqgM0pYoskCRlCiySJC+Urh2mheW91W9U/sZvFWjUdyYAwFAx6gAA\ngCGhhHA/1aGbF8okyXPNlZS/UVbeskTV6aIWKVVa/X5boaDvMACAgWPUAQAAg0AJ4QQW2NheWuS5\nMv3JXtnYwuWs0rSaaxooW8w6XX4bFHuubN/3PhYp0qzvXACAIWLUAQAAQ0MJ4RSJ3ypQIPlz3Uoa\n683yRNFUiQUWaK5UkYUbjwskn0m29o2QTW1qY8X6ns/7jgUAGCRGHQAAMDAsp3iK1AJF5TdA5UrX\n9lJjPZckz22uRIWnkuVKbL48oTTR3GJJuWKly22xKjYA4DhGHQAAMDCchXACL5QolSy2xQWyJlou\nV7U8qVRKlShYnlAa+cwzzzQ7MC8VAIA9GHUAAMDQUEI4TaKZJdLaNbbz5a3V0lXp2iGeVB3Uebp5\nUikAAHdg1AEAAIPCRIZTlYdpgY2VS6vrbkueW+6pJPnc8vKEUos1Umi5Z5JNVWhsUbXwVWLipFIA\nwB0YdQAAwICYN7u5qU96jdPo8+/bmoU+t0DywmJtHY5ZuFikanWr7wwAgEvBqAMAAIaOsxBO5PPF\nZbN2v81ZHcCx3jUAoAmMOgAAYEhYCwEAAAAAANRACQEAAAAAANRACQEAAAAAANRACQEAAAAAANRA\nCQEAAAAAANRACQEAAAAAANRACQEAAAAAANRACQEAAAAAANRACQEAAAAAANRACQEAAAAAANRACQEA\nAAAAANRACQEAAAAAANRACQEAAAAAANTwqO8dAHB97Cu97nsfKs/8owZz/Vg/0V/7jlT50H/WYLLf\n6F0PGW78pw1m+KW+7SFDo+0A4OGy3+lt50/6vn7v/9N3cgCXhhICgOa99knfu1CyaaOb+6d+7Vnf\nmVpJ9q6PFms4w7dXkAHAw/W2+z7M4r5DA7hETGQAAAAAAAA1UEIAAAAAAAA1UEIAMAgWnv4IC7bu\nCbbvGYJrTXY8FxkAoG30YQD6wFoIAFpmgcbVzUKZ53v/Zqrbkzc8KueNWqCoXKHACxvbzIvh5Lre\nZHfmIgMA3Bt9GIDhooQAoGVeaGKup55LNrWRv9j+C0uUnXpIs/gmxRIFKuxLpT6TNNNYHS1IdXeu\n6012Vy4yAMA56MMADBclBACts0hF+R2KT8wt3bmqQeLPT95oolSyUJFPJCv0ylIvvLDCokNnBHSe\n63qT3ZWLDABwFvowAEPFWggA2herOvSxRIW2Dl0s0vwe2ww9lxRobIHkmQJFkqRMyTByXW+yGrnI\nAADnoQ8DMFCchQCgfVF58GOxxvp458TLWEe/D7GpYgWaK1ChvJrZGaqQJM9lUnmAVc30zG06kFzX\nm2wtFxkAoBU1+7B9PRh9GIA2UUIA0L5Yc5tKCv3pnt8GOjabM1HqExv5zMa+WjgqUbrxZ6O1uZ3d\nrTd9PNf1JlvmIgMAtKRWH3agB6MPA9CiRw1XIp/0nOdZo3me9ZLhyQCrwx/qm753oSU3etf3LjTo\nid72vQvLPVljkVR9s/uljXx2+GE20uYFqjLPPC1P2LRw46TNwNf+n42rZaJK6x/bm30/3eiL++S6\ngGTPLFw9b/1kZ2ZoscfuLEPD7dDgtupj1OkSo87QDCfDvUbOAz1Y3T7sA31icd/BJV3bO+OxpH/0\nvRMNGs675GFnGM7ImD3yRldl7f0w5HWTeXpK87bZNgG6t/XeWc7nVFB+kLZIhc+l9Y+tknTwIGnk\nLyxeHfRszgG1RHNPLZSqra1/v9Lo+2nrQGsn1+LSWRZrfmHJphv7uy/ZgTY7K0ObPfbuq+5A25yZ\noeF2aG5bJ2DUAQbgjD5sqwc7oQ/7i361ZyFgADiK5RQBtC1azjqPlEn2c0kvJRup1ncftvgYu/rr\ntRM0LdbcU0mR32fpwiZzRRYoUW5vpOX1vK8lWawDbXYxGX54uG0GmwHAw1W7D9vTg9GHAWgVJQQA\nLbLIpooVVt/f5wos0VcKlas6LJKU3lFKGCmTVFRrSUuSFgtLWahXemNurunyng6+Udmbq5B8plCZ\nZ9UVvK8nWb7RZuu5LiXD34+0zQAzAHi4TuzD9vRg9GEA2sRyigBa5LnytSWcPlakuc/tP5RJqk6J\n99yOf2c/80Ly3MrDJlmyWkvf53pv66+3l5DqMldgQblKdnnV7etJJlm0arONXBeSQcWRthlgBgAP\n14l92FYPRh8GoG2UEAB0xovqu4+5oo2ln1KLD8/GXHyXsjwFMzo6c7u8EnY/uUYKJIW2umDgtSTb\nbrNlrkvJYOPDbTP8DAAerrv6sJ0ejD4MQMuaLiHc9Lyu6+NGt/Z+L2ne7+E5gY75rU1Xp1J6alPL\nvajzSDt6MSqbqseF4TYuqHVVycp0qzY7lGu4Geq3Ta8ZHjPqANjnQvowAA9C02shfHH+Js7y20a3\n9lkvGfp5VqAzFigs14de3eeTrYseHhbo4MWtLChP6ByS60i222YHcg04w64BZmh2DKuLUQe4SAPs\nwwA8CA2fheCf9h2o0TSf970HwDXyYt93IHVPrDy2orQXGuCh0TUk29dm+3INOcPefRpYBn/d978I\ngEsytD4MwMPAFRkAAAAAAEANlBAAAAAAAEANXJEBQPP6Xlh1bU8a3doH+mQwyZ40urV+lvFrdgHc\nG5v2kKHZdgDwcD3roQ+70f8pO38zAB6W/wewUkLoVmmAvAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAx\nNS0wMS0xM1QxMzoyMjo0MiswOTowMFr94/sAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTUtMDEtMTNU\nMTM6MjI6NDIrMDk6MDAroFtHAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVO\nRK5CYII=\n",
-       "prompt_number": 57,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fba9b0>"
-       ]
-      }
-     ],
-     "prompt_number": 57
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U6 = gate_sequence_product(qc6.propagators())\n",
-      "U6"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.354-0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0\\\\(0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354+0.354j)\\\\0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j)\\\\(-0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\(0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0\\\\0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354+0.354j)\\\\0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j)\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 58,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 0.35355339-0.35355339j  0.00000000+0.j         -0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "  -0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.35355339+0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339-0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j         -0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j         -0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j]\n",
-        " [ 0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339+0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339-0.35355339j]\n",
-        " [-0.35355339-0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j         -0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.35355339-0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339+0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "  -0.35355339-0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j         -0.35355339+0.35355339j]\n",
-        " [ 0.00000000+0.j          0.35355339-0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j]]"
-       ]
-      }
-     ],
-     "prompt_number": 58
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "qc7 = qc3.resolve_gates([\"CNOT\", \"RZ\", \"RX\"])\n",
-      "qc7.png"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAB7AAAACSCAQAAABm4Z1rAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAZdUlEQVR42u3dvask2XnH8d9jxgs2I9a1CkZY\nwYUab+JkWdVgW3Iwwq4RCEUOatHidWToiwMnAtEN+gf6otCBmAZlApnbaAUC4aArUWKDPcWiWGzD\nBMa7gbe01mKHx0G/d1f37ZdTr/39TDB9+/atOk/VOafq6ao6x5wAAAAAAMClfq/uAgDwz4bXsU50\nCbUWAAC0Hwk2AAAAAAAekGADAAAAAOABCTYASRYe/q0FW+8E2+8AVaPWAgCApnlUdwEAlMsC9ecv\nc6UuK/zMUHcHF9Jzg/myIpdKksutbyOX1x0duurhekutxXWxD/SX+rz01bzhvld3pECT2E/1uvSV\n3OgHbtqyMnvtK+z7+nLpJT7kxr3vc3Ek2EDHuVwDc3rmMsmG1nO325+wROmhpGNx1c8SBcptorEb\nSRqpr0Hd0flgiRL9sZz+QGN3d/ny4MND9fbaay2u0Cf62eyrojIx8B+w5bUr/ahhQ5/pdVVl9rq4\nL5df4gqjIcEGus8i5bMrgG5gzsY7p2iJe+/gAhKNJQsVuYFkue5t7HKXW25R8RXx9rBALzXVrSLJ\npda3iQZtj6krHqi3V1xrAQBAc/EMNtB9seapiSXKtZVcWKSHvjcNXSYpUN8CyaUKFEmSUiV1h3ax\nvlI3WFwJdXcaiOs3TXGg3l55rQUAAI1Fgg10XzRLTixWXy92bquNV6mLDe2VfWwTe2WTxe0yFiqX\nJJc5c/ks2Zk/0ZrNU5YSWWKfmbOPrZQ1WazQjdbfcZlS65+7vPoi6aRD9bbRtRbAJvo/ANeEW8SB\n7os1taGk0D0r+G2geepiicZuYD03sv7as8iJxhuf7609w1rymMwW6KUCSaHu9bSULbPzzLW7s4m8\nP4ldeiRddKjeNrjWAthE/wfgujyyuKQlP5b0Rd3h7XiiT+sugkdf0Sd1F8FrNF80sMacGkNT9sib\nq5cWSfPRlCfW27xeu8mNZ7feWrhx+22wPvSG9eeDRc2sX1W8KaE3eXeZDIX2QQlb96+Uzkv9rmSL\nd/+ohZGcrzl99ZP1H46ttxfW2ielHQPP97Z+U3cRiGZDU84c3q1kW7axJ/ehC+cgK4/1uKHb+ZQY\nGnlsKsmbntvdm5cv4kF++4qbCkp8iOezAW4RB7pu+SSrAi3nDbZ4z5zAPZcqXKUgm8+6WqKpG1m4\nnH+47GuBq9PJ35VysmCXL+LkSP6n9ac91Sioty2ptQA2ld2TA0CjPCp/ygcAVdv4Hi5aPq0aaSBZ\n5DLrKVQsbU9YZItUZpXcJKvbpS3W1GWSIjcuWOnrMnoTu9VLSbluS1l6LM2Wa1q8kqzfvki6YOvb\n4516q6iEWvtpA/dG80pENI1Q0feBLezJgTJVcp/T535bRiVl9tpX1H43meezAa5gAx1mkQ0VK5x3\nXJkCS5RLbqQ7TedzDo616tZ6SiXl68NALQaXslD3emXOnFYDSZV+quRGekv/rKeFydHlRtoZ0MyG\nGp2zqJoj6ZTietueWgtgE/0fgGvCIGdAh7lM2dr1vheKNHVTySKFbjSbD9hla6Nmj1wuucxuZz9a\nshqr2U311tbitweSKieG3F7vjHzua9lTy2zo1q6IWqLQDc5fYl2RdEtxvW1TrQWwif4PwPXgCjZw\nNVzuUjeVLFSiyCbLK37jxa05y/mgF0+wRgevN8xmGm41N5BsMps6xiIbKtFt3WXCplm9pdYCAIA2\n4Ao2cHXcdPMpVje2oWW71xbs4GBQNlRJV3or3hoDC9XTX8vpI415PrCpqLUAAKANSLAByA1sNaTU\nSrD/aWQLZjfmdoGbarAa7gxtcd21FgAANBMJNgBJRbfNrs8kvPO7XCQqqBm1FgAANA3PYAMAAAAA\n4AEJNgAAAAAAHnCLONBFNxZfvpATPak7aLQctRYAALQeV7CBLvplDev8ed1Bo+WotQAAoPW4gg10\nkPtJ3SUATkWtBQAA7ccVbAAAAAAAPCDBBgAAAADAAxJsAAAAAAA8IMEGAAAAAMADEmwAAAAAADwg\nwQYAAAAAwAMSbAAAAAAAPCDBBgAAAADAAxJsAAAAAAA8IMEGAAAAAMADEmwAAIDOsrDgvcCCussF\ndBst73o9qrsAAAAAOJ0F6s9f5kpdVviZoe5233W59W3k8rojANrnmHZHy7tuJNgAAAAt5HINzOmZ\nyyQbWs/dbn/CEqV7TuZH6mtQdwRA+zzc7mh5145bxAEAAFrJIuWzK2huoJ7FOx9IXFr8ly5XblHd\n5Qfa6MF2R8u7ciTYAAAA7RRrfhpviXJt3axqkaYH/jZVUnfxgVY62O5oeeAWcQAAgHaKZif3Fquv\nFzu3pMarU38bKlagqQLlytxAcpkN6y4+0EqH291ay9ttd7S8a0CCDQAA0E6xpjaUFLpnBb8NND/1\nt0RjN7CeG1nf3a39HsDpDre7Zcvb0+5oeZ1Hgg0AANBCFkmza2I2sZ4b7f+kG89uW7Vw49ZVxjIG\nTnZxu6PldR7PYAMAALTR8klQBQolyQKLJYuLZuBVz6UKN07tuY4GnG6n3R1sebvtjpbXeSTYAAAA\nbRQtn7GOlEr2TSXK7JW0nKd3yRapQHz00gEU2W53kQX7Wh7t7jqRYAMAALSMRTZUrHA+RVCmwBL9\n1o0UKnXpfGbe8dppfU+ppFzLCYIsVHraOoFrV9jucmlvy9tpd7S8a8Az2AAAAC3jMmUaLH98oUhT\n5RbMxi+2yGWSy2x1PW3kcslldrt8J9G47iiAdilqd25qwd6Wt9vuaHlXgAQbAACg1VyuVLK+Akmh\nrabnGlvs0vknZp9cDbYUuuzE1QBYM2t3knr7Wl5Bu6PlXQESbAAAgA7YmAho9s7YhpYVzNMrG65d\nhwNwAVoeNvEMNgAAQEe5gQpGFLdgdusqgHLQ8q4ZV7ABAAA6q+h2VJczEy9QLlre9eIKNgAAAAAA\nHpBgAwAAAADgAQk2AAAAAAAekGADAAAAAOABCTYAAAAAAB6QYAMAAAAA4AEJNgAAAAAAHpBgAwAA\nAADgAQk2AAAAAAAekGADAAAAAOABCTYAAAAAAB48qrsA18r+Tb+quwxzN+59j3H9i35NDGd47r5e\n+TrRIfZTva58pTf6pftJ3ZE3iX2g79SwH4o819+6qcfI6jhiea5ftcTwjvt25eu8QjWdeRTxusdr\n6dd9x/B9fa3yKDg2oXYk2HX5lRvUXYQZG3pd3K/riKv9MXiOANfndQ21Nq476Mb5RD92ad2FkCQb\n+kyvVcsRy3v9qiMGevZq1HLmUcTzHq+hX/cew0f6qOpekWMT6sct4gAAAAAAeECCDQAAAACAByTY\nrWHhOX9jwdY7wfY79TscWftjaEcEuD5daHnt56Nnb+aeOa1+NTEGWkh3cUZFDChStO2bvn2beQZe\n0jPYFulbkv6jGU+jNZ0F6s9f5kpdVviZoe7OWHRv9vyOBYpm+8Ll1reRy1sUWftjqDmCdrNQsZ5b\norT928sSfcN6yoprkdc1daDltV/ZPXuT+8TT61fVtevhKGghPlmoWF+3nsblbx8P+7ZY+89GiOFK\nWazVc+npbKtZrHjxevm5wm1fz/bdLXNRiZt7Bl5Cgm2Rhsr0v5JiG2pAkv0Ql2tgTs9cJtnQeu52\n+xPnpReL72gsUaDcJhq7kaSR+qpo2IzLI2t/DPVH0F4W6KVyZfpcoe4ta8owNmfFkqivVL9VrsSG\nuvU8BNWWLrS89iu3Z29yn3hm/aq0dj0UBS3EHws0lJTp/xRU0ZNfum/3RrH468a2vObX2i7E0EYu\ntUyf6S2XS9a3vt5zuUtnCevqUwe2fQ3bt6DMOyVu9Bm48/xPiSYKnRQrdlKge/V8r6ML/zTc+CnS\nZ8vXTvHOp+/PWkdPkZPC2boU6zMFTk7qK9pXEr9xXR5Z+2OoI4Ju/FOgj2dbe77t+pqUuLZ4d896\nXPpQQwXLSCJN1ve+nzVs/VxByyt3m7Xx3/YWKa9nr7pHOe2IdW792orBc/06rY008thUSYvzXncC\nTcruyf3u2wbt8S6cUXnuFes4NlVxhlZunz3b2stXr9SffWarZz+w7TfrSCk1pWBp22XeLrGfM/By\n9oDnZ7AtUF/vra7NuNy9p+ScZ12uzPIbGUuUa+umGYt03tWu0GWSAvUtkFyqQJEkKVXSmsjaH0MT\nIminl7pdv//F3Smz/vmLq4/FCt1g9R2ry3Srsqfv6ULLa7/yevYG94kX1K9qa9eBKGghHr3UXeU9\n+WX7tlgT9ngX+vUuxNB2uQqeQn5g29e9fc8pc621xfcgZ33d7Vyqv1Ov7DBaL5p1Mharrxc7WzDW\nwWc2bWiv7GOb2CubrOYvtFC5JLnMmctnXdn8+YNsXsEaFVlRFO2KocERtJCFiy214gZldYmW6ENN\n7GMrZ5/0tHUbnJsqtXL7xQtqLfXWm9J69kb3iWfXr4pr16Eo2nFsaoFqe/KlI/ftnjI3d49f+RlV\nY2JoNYsUaTT/IbDEYru3QA/Un3q371qZ10vc6DNw389gR7vP1ri0nVedKhVrakNJoXtW8NtAh55H\nSTR2A+u5kfXd+oP+icYbH+ytPXFQ3XiAR0a2J4oWxdDoCNooUdHoDalF/ocIs0Av9SVJoe71tIRY\ngoIUZKxy+8VLai311pfye/Ym9omX1K8qa9ehKNpxbGqD4nS2lJ58Y61H7Ntijd7j135G1ZQYWsqG\nknJJT9fuqBtL1lek9MH6U8v23S3zWokbfQb+yPzeqPiny+XdSLYY/+2p57Wc76v6z7qLMHezemmR\nNB/lbmI9Nzr0Z9bT5g33qRvPbpKwcOtGiWB9GCXrzx/tn1k2LQv13OveeWejtEdHtieKo2KQPMfw\n/JwYLozgpjFt5Eav6y6CJOl9fbi8nrzav8/1rn1UQsyLrja0H+lz78v/k1X51/bzt/zWWgtXde3C\nWntsvf2KvmOxmqApPfuNfrn64fj+r6BfP6pnr7BHOeuIdUb9Wo/Bd/066+h0Yc/+jtf9sFG/SuP3\nePq+Pizo/3z35GeeeZzQ8lp0NtLkWtvSY9M7ly/i4e1UXp+9tDMCd/GXTXu2/u5nS6zte8t8SomP\nrfEzfuu9HvkdzdGixS3iFkuLjWJRm0f/LcfGblyNiResOnuLlUnbV772dEc9d2vxenXZfC7BEk3d\n2EJpXtmW39y4qf3K597Zqp47kc0GyrdY04JRlLeiODYGSZXGsG/fXBTBa9rIJpuuarsNF1vHXmpU\nyhXs785f5u4fSohl2QOuRbI8zfC0juFGizqhTzm/99An+jGzRKzbOqU7ei/sPc08uG+q7FEeOmId\n6NlPq1/rMXiuX7X07L/22sqr+TrL7/G0uCcfauyzJz933x7b8pp6NlLSGVWZtbaVx6ZKLoCU2Wef\nY2frF1zzLbO2X1ziE2r8jNd67/8Z7ILHxu3B512uXrTcQpHS2am39RSrf9xNpLbopta7sbUbIyzW\n1I0lReVODXREZN9UosxeSbuRFUTRzBiiffumsRG0U6qdk0kL5gNWeOby+TPSuW4vXFSxvODZ7qTU\nfvHoPqXBvUf7ldqzN6pPDPb17A2uX/Ts1Sg6KwxU7g3iR+/bYo3d4508o+LY1ESFW7/RmlfjfSfY\nI/Vs41sBC/TQlPFXzSIbKlY4/44vU2CJcsmNdKfp/NuU8QNVvKdUUr75yP7iu0ALda9X5swtxi22\nUBVcdSqM7LdupFCpS+dzH65HVhBFI2PIN/bNegwNjKC93FRT2z4x62t01sIeXttIb+mFnrrx5csq\nMNgeM9wiRSWt69Q+pZG9R/uV3bM3q0+U9vbsJ9WvqmrXET17w49N7eGmBWOGl9aTn7xvizVwj3f3\njIpjUxUstqGkZP1+AosVKbLYegqVWHy4/lS/fXfLvFPiZp+Be5/JbT7D63we7EgTJb7X0YV/xfOt\nKVCscL4dE6fFPG0PzPMWzP8Pl+8kh7Z6lbM2bkamQIH6xZFtR9HUGLb3zSqG5kTQlX+aLOZqdFKg\noV7WXaKzI+lponA5D2ysV6vW6mkND9TafX3KJb0H82DvbJ09W6SKnr3KebC349rfs18UQ0Vz2Rb3\n7I08NrVyHuwqevJz9+2+v2rMHu/CGdWZvWKTjk3dmAf7iL/ZW3/qmgf7+DJfUuPL2QO+r2DPZ3i1\ne/293rd7DXVb1nWaLnK5S91UslCJIpssv4kZH3r2ajmy3urGh8NXx0q5zfaoyHrqK1Bo8fLJiGVk\nO1E0NIadfbOMofkRtI17ocAmNtSf21ATZa6cG7iriGSkgV7aS/2F9W2iWC+quk3poT6lDb1H+1XS\ns9fXr2t/z978GPb27C06NjVdfT35Q/t231/N/2/sHu/OGRXHpkbZX3+au30bewbue5quWXAvLNA/\nSvqngsFCcAQ31caj9m5sQ8uO3Zp2cPB5G6q24bTczsMC+yJrcAzT7XUXx9DcCNrEDSSL9Vr/3vZB\n4FymFxbqG/pEozr6xWP7FOptmcrr2evdM3569ppjaEMLeVdfq2CgsxJGTK63J+eMqrkxtKTl+R0t\ne986wrqfJt/fMpp77G/uGXgJCbYkudz+tXAsTpzJDSw6elCkYP/zTRbUc3p/cmTtj6FVETSZS7vy\nZJWbqkGDsXSh5bWfn569iXvm1PrVvBia10LcD+veJheVvkE9OWdUxHBSib5e9zapSvG2b14debDM\nDajxJSXY8O/42xkOfQfmcjWukRRF1v4Y2hYBrk8XWl77+ejZm7lnTqtfTYyBFtJdnFERA4oUbvuG\nb99mnoF7fwYbAAAAAIBrRIINAAAAAIAH3CJel3cqGDLhOG94XdpXa4mr/TGUMKwMrsobNdTaJ/p5\n3WE3zB/qbyoYhOoY73geMKeOI5bv+lVHDF+tfI3XqZ4zj8KSeF1aHf267xje1p9V3itybELtSLBr\n4r5ddwlKiuvv6i4BMeAaue/VXQJI7hf6Rd1lKCmyDhyxuhADinX1qN2Fft39SD+quwxA9bhFHAAA\nAAAAD0iwAQAAAADwgAQbAAAAAAAPSLABAAAAAPCABBsAAAAAAA9IsAEAAAAA8IAEGwAAAAAAD0iw\nAQAAAADwgAQbAAAAAAAPSLABAAAAAPCABBsAAAAAAA9IsAEAAAAA8IAEGwAAAAAAD0iwAQAAAADw\ngAQbAAAAAAAPSLABAAAAAPCABBsAAAAAAA9IsAEAAAAA8IAEGwAAAAAAD0iwAQAAAADwgAQbAAAA\nAAAPSLABAAAAAPCABBsAAAAAAA9IsAEAAAAA8IAEGwAAAAAAD0iwAQAAAADwgAQbAAAAAAAPSLAB\nAAAAAPCABBsAAAAAAA9IsAEAAAAA8IAEGwAAAAAAD0iwAQAAAADwgAQbAAAAAAAPSLABAAAAAPCA\nBBsAAAAAAA9IsAEAAAAA8IAEGwAAAAAADx7VXYDT2XN9V59Xvtob/cBN644dAAAAANBULUyw9fv6\nmUurXqkNSa8BAAAAAPtxizgAAAAAAB6QYAMAAAAA4MHVJNgWHvqdBVvvBNvvAAAAAABwSBufwd5g\ngfrzl7lSl+351FB3BxbSc4P5sqLZ090ut76NXF53dAAAAACAtmh9gu1yDczpmcskG1rP3e5+xhKl\n+5PlxbVqSxQot4nGbiRppL4GdUcHAAAAAGiL1ifYkkXKZ1eu3cCcjQtGGE/cewcWkGgsWajIDSTL\ndW9jl7vccov2XREHAAAAAGBTF57BjjVPqS1Rrp2U2CIdnmArdJmkQH0LJJcqUCRJSpXUHRoAAAAA\noC1KSrAt0Yea2McWVRBDNEuqLVZfLwpuBY8XSbcN7ZV9bBN7ZRMbzt8LlUuSy5y5fJakz5/DzlRF\n6QEAAAAAnVDKLeIW6KW+JCnUvZ6WHkOsqQ0lhe5Z4e+DWQpticZuYD03sr5bDXmWaLzx6d7ak9eM\nJA4AAAAAONIji0tY6rvL1DS0D/SJ96X/1+oHi6T5GOAT67nR/j9z49nt4hZu3DIeuLWfrD8f4mxm\n/Wr4m6Vsqct8xfu2rTeaL/RF3YW4OIb275EmxvC2flP6Oh7rcQWRN3HrPpZa3/Ke6NO6i+BRFfWd\naE7R3vpVTb92rGbXhS6cg6w0a8+fG0N7j0311/U3K1jHjdfM6KaCEh/yxG+eV84t4qtq9bvSG/jy\nCWwFms91bYHFksUFc1/3XKpwlThvPp9tiaZuZOHy77iCDQAAAAA40qOCMbc9sFu9lJTr1v/ybfPH\naDmsWaTBPGVONLZXGqivjUm7bJGCr5LyZDU/tsWaukxS5MYFq/28nC0F4EG0PVyTbtX3bkWDS1AX\ncC1qr+uV3HX72mdmVPt9wp/6zfNKGuTMjfSWXuhpYarqjUU2VKxwvlMyBZYol9xIoVKXzufEHmux\n03pKJeXrg5ctBkWzUPd6Zc6cVsOf1d5AAAAAAABtUdo82C4vPz11mbK1IcleKNLUTS2wYDZy+Gwe\na5dZf/6Jkcsll9n8urYlq0m93FRvbS1+e/gzAAAAAAD2Ki3Brt4ype8pkBTacnoujS126epq9XJY\ns8gNDixwNj82AAAAAABH6FCCvbA2BdfinbENLdueIdsODmFmQx1KvgEAAAAA2NDBBLuIG9hqMLSF\nQHsn9bJgdjs5AAAAALTGjQ1LX8cbXpf23xWU+BDP04RdSYIt7d7uvT7/9c7vcpFeAwAAAGgV937d\nJTi5xD+suwR+lTSKOAAAAAAA14UEGwAAAAAAD9p4i/hjvW3Vr/XGAp7KBgAAAADs8/+OTeNXh03N\nvgAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxNS0wMS0xM1QxMzoyMjo0NCswOTowMDkt1sEAAAAldEVY\ndGRhdGU6bW9kaWZ5ADIwMTUtMDEtMTNUMTM6MjI6NDQrMDk6MDBIcG59AAAAFHRFWHRwZGY6VmVy\nc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
-       "prompt_number": 59,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fbdf60>"
-       ]
-      }
-     ],
-     "prompt_number": 59
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U7 = gate_sequence_product(qc7.propagators())\n",
-      "U7"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.354-0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0\\\\(0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354+0.354j)\\\\0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j)\\\\(-0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\(0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0\\\\0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354+0.354j)\\\\0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j)\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 60,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = False\n",
-        "Qobj data =\n",
-        "[[ 0.35355339-0.35355339j  0.00000000+0.j         -0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "  -0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.35355339+0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339-0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j         -0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j         -0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j]\n",
-        " [ 0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339+0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339-0.35355339j]\n",
-        " [-0.35355339-0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j         -0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.35355339-0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "   0.35355339+0.35355339j  0.00000000+0.j        ]\n",
-        " [ 0.00000000+0.j          0.35355339+0.35355339j  0.00000000+0.j\n",
-        "  -0.35355339-0.35355339j  0.00000000+0.j          0.35355339-0.35355339j\n",
-        "   0.00000000+0.j         -0.35355339+0.35355339j]\n",
-        " [ 0.00000000+0.j          0.35355339-0.35355339j  0.00000000+0.j\n",
-        "   0.35355339-0.35355339j  0.00000000+0.j          0.35355339+0.35355339j\n",
-        "   0.00000000+0.j          0.35355339+0.35355339j]]"
-       ]
-      }
-     ],
-     "prompt_number": 60
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Resolving non-adjacent interactions"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Interactions between non-adjacent qubits can be resolved by QubitCircuit to a series of adjacent interactions, which is useful for systems such as spin chain models."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "qc8 = QubitCircuit(3)\n",
-      "qc8.add_gate(\"CNOT\", 2, 0)\n",
-      "qc8.png"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAABeCAQAAAAJMMufAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAABgUlEQVR42u3bP0pDQRDH8e9IShFiozYWC2Jj\nI3bWe4VtLeMRXo6gR9DO1neFXMEj+FpR0IBgPRYm/iFaOS/sg98vTZhi9sOQzRbLmhMfyxT2eeOZ\nmbc99I9G25iGxJQEdExInPs8eBEP/nDBxHHIZMehcBu9xkbwnDPJr38MpaWzErtKMJrCdKV2STB6\nZDm03xHJEgDHYMvqTuwq0ZO2X6vBu33ks1BzofNuqf/obWOeYleJnnRLs1JrCP6vDkb7jLlNvles\nkKIPmD4Olys6rknAHU0fh0s4GsAKmUOMR9pBHOOfjfNyI8YneiOuJUILLXQFEVpooSuI0EILXUGE\nFlroCiK00EJXEKGFFrqCCC200BVkkOjoC/2vnP51Uf7/DHLSukdcV4QWWugKIrTQQlcQoYUWuoII\nLbTQFURooYWuIEILLXQFEVpooSvIINHh78YXr8cLrzj3nPTR3ejj8nOTG7YAeOAsvn0/P4+DBRn2\n2I1v38/LzzEvi69z347v/w4SSe19aM5orQAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxNS0wMS0xM1Qx\nMzoyMjo0NCswOTowMDkt1sEAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTUtMDEtMTNUMTM6MjI6NDQr\nMDk6MDBIcG59AAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
-       "prompt_number": 61,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fc64a8>"
-       ]
-      }
-     ],
-     "prompt_number": 61
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U8 = gate_sequence_product(qc8.propagators())\n",
-      "U8"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 62,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  1.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  1.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  0.  1.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  1.  0.]]"
-       ]
-      }
-     ],
-     "prompt_number": 62
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "qc9 = qc8.adjacent_gates()\n",
-      "qc9.png"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAARYAAABzCAQAAAD3CuWZAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAEy0lEQVR42u3dPW7jVhSG4e8ERlKzmiJFAGUB\nRqAuzTTMEugqSGn3aaQlSE2AlNIGAphLCJvph4WbNIEFTBEgaYYB0k1zUpCiZNkGThD+iML7CAZo\n/V4ffOS9pEldc+HAMt1qp1SlEq29GLs958UIy4FtVGntla18aYk22vly7Dadk8/GbsD5sIUqX3pV\n/+aV32hm6ditOidXYzfgXFii1L87ufNO96IrarFl2Uufx8Ir7Ww+dsPOh2k1dhMkXeth7CboW/2t\n35rlt3r3wr3j+VJ/jN0EyZcMcBt2q8rzZnm1H9jaSgX7RHt0Q3uFXhrMpkTlgLA0fKfkdN/HFgxv\njxGWgzutjoezlinlOMsxdp1bXtmNNlaq0BeWKdNON2O36bwwwD1hc2X6QT+r8HLstpwbtiwnvFRp\n8vXY7ThHjFkQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQ\nRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQRlgQ\nRlgQ1vG3Vdov+jBY2z/3Hwf7rI7YT/o02Id1Xp+uv9r0w3DfSW3nMJ/Jf/VpyvWhG0IYYUEYYTlh\nmX3Uwh6Zwew5wvKEJdookTTT/dhtOT9XHc8v+mbAtn/Vw9yo3yhplmb2vf7s/P2HrM+bbuvjBVuW\np35vl/7pISoTd9XttG6DzoP8oY8p6exOG0mV7np59yHr81fXfwFTyJzwreWaq9xPBo4DwvKMV8yM\n+DLGLAgjLAgjLAgjLAgjLAgjLAgjLAgjLAgjLAgjLAgjLAgjLAgjLAgjLAgjLAgjLAgjLAjr+Uw5\nS5RppkpbpZ7brWaS5MvD0v4yy/qyTpsr9XXz2lSHM1aLPs6IHd/E6uOd3rQ6+X2jpL6/fkQrvW8e\nWehjs5Tovn6WSys9Hr06kTevX+jX/XNe+6wp3KZdn167IZtr1pz43KwNyjW3+sqcQkl91Z9Xyo9O\nj54drgX0qv6RfK1EtwOsO4OaWn36HrM0f/r+JGgvtVNWP6KiXrJsf4K0zZUrbx4/VbWXf12SSdWn\n17B4qUKPdm8Lm7V9at70tImKfZ/brjeplypeWkNsrrm2fRdjaFOrT89bFr/RWtJC79uNZ67MEku0\nU665zZ48PZF8K9nRumMrW9lCqb72Xd/FGN606tP7dUP12N02WuhGkry0nTJVnktWKrNdu5HNtLNU\nUqlUefsGF7ofNMX69DvATdvLNZc6fIVF3u7y5cqUtBvZuW+98ELbV3rlizO1+vQ9wD0cCSiPipG1\nS8ffgtIUxfOnG9qLNqn69N0NJbZQKSlrdw7lpZWeS5LvrKw3spbqVjMrvZBspUoLmzcDvMx0wR3R\ntOrT50EnJUpcSpWePGv2fOn/H+Cawm3a9el1y9IcMHqW+8O4/RL3cOKmVh/+kYgwwoIwwoIwwoIw\nwoIwwoIwwoIwwoIwwoIwwoIwwoIwwoIwwoIwwoIwwoIwwoIwwoIwwoKwq46nir4esO1ve5sG/FoP\nvb3zcK67rY8vr7qdwXzQWdzfDTf7elcGrc9D1/WhG0IYYUEYYUEYYUFY1xeZ9TGL+2uGnH29szZP\nuT7/AvbNjHpepyl7AAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE1LTAxLTEzVDEzOjIyOjQ1KzA5OjAw\nn1rddQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNS0wMS0xM1QxMzoyMjo0NSswOTowMO4HZckAAAAU\ndEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 63,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fc2a90>"
-       ]
-      }
-     ],
-     "prompt_number": 63
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U9 = gate_sequence_product(qc9.propagators())\n",
-      "U9"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 64,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  1.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  1.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  0.  1.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  1.  0.]]"
-       ]
-      }
-     ],
-     "prompt_number": 64
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "qc10 = qc9.resolve_gates(\"CNOT\")\n",
-      "qc10.png"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAByCAQAAADnwV5bAAAABGdBTUEAALGPC/xhBQAAAAFzUkdC\nAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAJiS0dE\nAP+Hj8y/AAAACXBIWXMAAABkAAAAZAAPlsXdAAAG6klEQVR42u3dT4srWRnH8e+jLZeBQSgEnV1L\ngW5cSc1GNxekeudiHKgeB8aNiwRfwJC8hMor0PRWQUxgQBfjIkFwM4Mw4bqXG7g7Fe3iDo3i6ri4\n6VTu03Hh7XpSU7d/nyz6dC3qnJMnvzr1JxBLiMihs74HIGAVFRlf5+9smKWm7/E8dF/qewBicwrG\n6YLfpws2rKzoe0QPnULRM6vZpunt6pCWXDC3rO9RPWwKRa8sp0izwy2pYcak73E9bApFv0bM/Ka0\nRCdQvTqzMmjPbwI34eN/i7+G9wHf4G9Be/4B630Fzvetr4VV5S1uTlCVb/GX8D4Ce9FK0a9/8uaR\nrdb3sB62s7TuewgPmRV85bYCVu5b/xh4VU4z+rBetFL0a8nIb7L6RB8q+R8Uil6lLWubH26x0t+P\nklNTKHqWZmxtZRWA5VYz4rLvMT10pu8+9c9yRuQUrFkO/GritaBQfGFYnaZ9j0FAp08idygUIo5C\nIeIoFCKOQiHiKBQijkIh4igUIo5CIeIoFCKOQiHiKBQijkIh4igUIo5CIeIoFCKOQiHiKBQijkIh\n4igUIo5CIeIoFCKOQiHiKBQijkIh4igUIo5CIeIoFCKOQiHiKBQijkIh4igUIo5CIeIoFCKOQiHi\nKBQijkIh4gw6FJbbB1b2PQp5meX2Myv6HsV9nPU9gFdlBRMavskfrGbNLDV9j0jASiZs+TbnVrNO\ns77H82oGulLYiJppGvMkzdLbbFhY1veYxGoqLtOYP6VpugBb9T2iVzPIlcIKqnTR/p+W1jDnsu9x\nPWxWkqeDGqSZYXWa9j2u/1/QSmGVXVuyp0HnlhPGL29Ia5qYvoJnctALk9hewmdytyozcssHOJcU\n8CLjetd8GrL/1b5V71tl2x7OTE7XS3hNcuZHqjJiNLy5nFkdkLRzbs/wc/s5zzvf/3f2o358MP73\nbHgzOV0v0X18l68eqcoj3g1YK6LnEnRUum1eh+x/ceSYVAStFKEzOV0v4TU5eP8PWhWT4c0l5Joi\nNbuzy8afZXYkO3KvqWIzwJmcrJd9H5/H9JE2HHtiVLIOnEvU+xV2ZHqHD8mC9l3dHov2f/P2OiPg\nuPTrqJm81EsZ3QsZH/JO2N4nd6pStmv6kKoS95zihidRD9TSkuzwWsgK5oTd+ksNz+IfDaYmraN7\nSQ1PuAnb+4zCJu3/VjIPXfnCqjLI5xSQxjaxFWseWUlJwTht+x6TpAurbcWSR1ZRkvH2ML9nMNAn\n2pBmXLLlhxQs04Ui8cWQpoyBd8m5SpfDjMRgVwqA1LC0Yqjfr3ldpS1Xlg+7KoNdKUSiKBQijkIh\n4igUIo5CIeIoFCKOQiHiKBQijkIh4igUIo5CIeIoFCKOQiHiKBQijkIh4igUIo5CIeIoFCKOQiHi\nKBQijkIh4igUIo5CIeIoFCKOQiHiKBQijkIh4igUIo5CIeIoFCKOQiHiKBQijkIh4igUIo5CIeIo\nFCKOQiHihPw6qmWU/BSzjPAfTI9mBSU/soZ12vQ9lnvOJKPiA/71WlSlpOR9a1hG/Fh0wEphFSty\nfsevyFlZFf8WRbHMFozY8jFbRrawrO8R3WMuExbAFb8lZ2Vl3+O5x0xyW1Gy5iO21FYHVCV1/GLE\nnCxBSZkgY07ddR8HvUXuO+MzyrYXSj4ji+sv8kW9n8OLqiyoBlqVnBXFQVUqVl330fFKYTlVGreL\nc2rSmMKK8MNHhJppWrf/pjUzJn0P6lVYQZGmBzNpGDMZ6Lo3Z3p4IpuWbKzjqnR9+jTi6s62MaPu\n3xuwyq6Z2NOYyFlOdhgJgLSkGORHacTYzaRhNsiqlGz8tV2a0vHJYNehyNPSb0pbAj5IljEnA3IW\n3e8dKFgf2bpmiKtedvdyNC27/ijBCapSHq3KptsIGnWng/4Jv9y1zoFnu/ZlwFt0zo/37V/wvPP9\nP+Y5f963/7hrfQ/4tPO+bmf07P47Oeo9frPvo61Ku7XLOcRW5X0+4j+7dluVx3zOkw576fgyaHF7\nKfrikm7X7vxSKEG2b16HXNCV7eXiYevFRd6wXu3731aFnPkAqzJidKQqi25vgHR9+rS5e6Zqo6NL\n3n3D3OzOkxt/vtzR/td3Ty8soxzk04rNkVuwIwJmEl0V1ty5xW8ZWcfPXbo/KpEfHpPI4m5kklHG\n3SRlcnssav9G3siMe5GxevE+7atSRKzeJ6lKzcRVZdH16t39w7spi/aBnZWsGEc9P01NCnw2m2Zk\n7aMhy6yGu7cRhiA1TFm1F6NWMQ86khNelSml7a+DLbNV9981sNT5sC1jQsG/gTfYMh3yVwqsYsSW\n7/MJOVfDjMRuJhk1OV/mhjfYMBt0VSaUbCnZALPuT2j/CwKidclkwi7UAAAAJXRFWHRkYXRlOmNy\nZWF0ZQAyMDE1LTAxLTEzVDEzOjIyOjQ2KzA5OjAwrrLH6AAAACV0RVh0ZGF0ZTptb2RpZnkAMjAx\nNS0wMS0xM1QxMzoyMjo0NiswOTowMN/vf1QAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwL\nOQAAAABJRU5ErkJggg==\n",
-       "prompt_number": 65,
-       "text": [
-        "<IPython.core.display.Image at 0x7f3317fc6b00>"
-       ]
-      }
-     ],
-     "prompt_number": 65
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "U10 = gate_sequence_product(qc10.propagators())\n",
-      "U10"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "latex": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 66,
-       "text": [
-        "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
-        "Qobj data =\n",
-        "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  1.  0.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  1.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  0.  1.]\n",
-        " [ 0.  0.  0.  0.  0.  0.  1.  0.]]"
-       ]
-      }
-     ],
-     "prompt_number": 66
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Software versions"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from qutip.ipynbtools import version_table\n",
-      "version_table()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "html": [
-        "<table><tr><th>Software</th><th>Version</th></tr><tr><td>matplotlib</td><td>1.4.2</td></tr><tr><td>OS</td><td>posix [linux]</td></tr><tr><td>SciPy</td><td>0.14.1</td></tr><tr><td>QuTiP</td><td>3.1.0</td></tr><tr><td>Numpy</td><td>1.9.1</td></tr><tr><td>Cython</td><td>0.21.2</td></tr><tr><td>Python</td><td>3.4.0 (default, Apr 11 2014, 13:05:11) \n",
-        "[GCC 4.8.2]</td></tr><tr><td>IPython</td><td>2.3.1</td></tr><tr><td colspan='2'>Tue Jan 13 13:22:46 2015 JST</td></tr></table>"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 67,
-       "text": [
-        "<IPython.core.display.HTML at 0x7f3317fc66d8>"
-       ]
-      }
-     ],
-     "prompt_number": 67
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# QuTiP example: Quantum Gates and their usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Author: Anubhav Vardhan (anubhavvardhan@gmail.com)\n",
+    "\n",
+    "For more information about QuTiP see [http://qutip.org](http://qutip.org)\n",
+    "\n",
+    "**Note: The circuit image visualizations require [ImageMagick](https://imagemagick.org/index.php) for display.**\n",
+    "\n",
+    "ImageMagick can be easily installed with the command `conda install imagemagick` if you have conda installed.\n",
+    "Otherwise, please follow the installation instructions on the ImageMagick documentation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from numpy import pi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qutip import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "http://en.wikipedia.org/wiki/Quantum_gate\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Gates in QuTiP and their representation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Controlled-PHASE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0j\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[1.+0.j 0.+0.j 0.+0.j 0.+0.j]\n",
+       " [0.+0.j 1.+0.j 0.+0.j 0.+0.j]\n",
+       " [0.+0.j 0.+0.j 1.+0.j 0.+0.j]\n",
+       " [0.+0.j 0.+0.j 0.+0.j 0.+1.j]]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "cphase(pi/2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAGEAAAA9CAQAAAAXQ8+kAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NMRILqyYXAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAadJREFUaN7tmjFSwlAQhr/nUIIMjoVWaLyADFegs7FBO0s4AhyBK0BpQ0Fjb44gB7CQGSo70thYrYUREwsseKsLs18K8nYy75+P95IwwyLoHXRZIbzQ1kwJtGmgQ5V7agC8cqeUgaQVOmoKzVwATrniXSklDaI0M4QGq/w0kyO1GA70ppaM/qdA/qkWpHpwzZSGbobiKgDwxlIy3QhthT/AFSzgChZwBQu4ggVcwQKuYAFXsIArWMAVLOAKFnAFC7iCBVzBAq5gAVewgCtYwBUsUIk7XbjkuFRo0QydUqUqD5Ez4/7vHKbAslCoc8Jz6ZJbOY+rEHkVWJJKulGyHTlxH+6FPVCIvZEKhFFhMJfZDirQoy8zCAlP3OjFaG6kSf7Nj3+7xbdDcxVmAKFLmwvFFCohbldYk+rXqcwhNBgzLDWS1H686rYkflfY2bcCAAPmMilVDomqQBq7/2hEpzDqsCIRBHrr2uNu9SONmcgCQK3/D9UnUhiRyRAgJJoKak+kkDBglr/eeky2nO4/FGRBWA+GegJ78RtpDxRib6Q6rbD5iuhNtx8ml10sQQgmdgAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOS0wNS0yOVQxMzo0OToxOCswMDowMHCTlaUAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTktMDUtMjlUMTM6NDk6MTgrMDA6MDABzi0ZAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = QubitCircuit(2, reverse_states=False)\n",
+    "q.add_gate(\"CSIGN\", controls=[0], targets=[1])\n",
+    "q.png"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Rotation about X-axis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}0.707 & -0.707j\\\\-0.707j & 0.707\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[ 0.70710678+0.j          0.00000000-0.70710678j]\n",
+       " [ 0.00000000-0.70710678j  0.70710678+0.j        ]]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rx(pi/2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAH4AAAAYCAQAAACWh4FEAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NMTDey2fzAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAglJREFUWMPtl8GN1TAQhr9BXBGyRAVmKWBlSvCWkBZMCUkJ2RLIDXF7KeGlBNJCJA5c8YEChsNL3jrvhdUibN4+weQyccbj+cee+R1Rcop85h0/srpM5Y3e5nT3MnN43/ikQynsss/r70WpQK9B/oO/rIj9xbgRU3bl3DV/Ej71rEYGHTdtarrE3s3qqFGj1NJpvFLwGmlEea+jGGoJ+uEMesW4wBNHhWXCMjERgY6apmSAWR9a/Ord8X3WDIo7s98nulEICm0yVqdzUuscT+ma9yzEVxFPD744khGNYrDiViYDVbngSoOf4Ymn4m4jNet0BHomEvg64igmRWse8EzSAlbvNr4aVu1M7wFOklSw45ft9g60AZC9BO3ODNyxKJCwOuD90bpkt5eP2D93c5Qbvj4ASireLDsoBqeDeEaNq4rv6DY9pjt/k/mCW7Lbs6OeNcUrOAwBwxc87QY3WFrCI3xwLd1enLR4rHgARoxURNAOy6CDNkCPT2ZYKm1A2tXY+HvrPpudTzkcj9XD8a+plAN/s0tsqgPDLzeD8jxfutsvKY5z9QcMYGUhuV788gusPT1IWNW+1evf+Udm1Jjkza3ud2367Ypq/snJv39gG3FYbeYugRiK/taUv+Q8Bf54hL5jksBcIhpLcvwzAZ8k4e3fXfHix/6S8k+Dz33sX3Mr5aJ9ldfdTxksT3lFp+0TAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE5LTA1LTI5VDEzOjQ5OjQ4KzAwOjAwOHObwQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxOS0wNS0yOVQxMzo0OTo0OCswMDowMEkuI30AAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = QubitCircuit(1, reverse_states=False)\n",
+    "q.add_gate(\"RX\", targets=[0], arg_value=pi/2, arg_label=r'\\frac{\\pi}{2}')\n",
+    "q.png"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Rotation about Y-axis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}0.707 & -0.707\\\\0.707 & 0.707\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[ 0.70710678 -0.70710678]\n",
+       " [ 0.70710678  0.70710678]]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ry(pi/2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAH4AAAAYCAQAAACWh4FEAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NMgTUUsCFAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAjFJREFUWMPtmMuN2zAQhr8J9hos2AKTLWDBlCCXIOSUq1KCVIJcwvoW5JS4BLsFVmCAQA65Lg8pYHLQ23ICLCzaMTajC19Dzk/OP+RIlCVFvvLAr0WnHOQtB/205IR3Cxv4ky+6T4NdMrJlZ3yTxtDbkP/gryti/9BuxKRdeWnOH5lP2RYje/Unx5Rs+tGubfQaQaOUstF4o+A1UonyQb0YSin08wx63gAFceRYApZAoIG8oaRKaeCiHzXZpO54bksGxc3G7/qSUSgU6kl/OeiQTfvO/1JzPqO7+HLiseOLo2/RKAYr7kh/T57OuNTgW3iSkbM6sTXj7SjYEpjAV48jmSTlPJARpAasrk70GkbhTNcAsy1KGPHTRnsHWgHITgrdzAa4nhTIbtJT9RRJGe3lCXv+NL2858cAaMR4052gOKIGEKNx7PQnPaPR7OSBj7IoCe7m1885IjWHUXUIaI4KxGGIPLGSAph5glgKwpGHDCd/4JsuevElC3jipCbDSpOMeIzkRDwWT+fw23GqIpZcK5B60uZftOyLJBnn1eNHD5QVjqABpIFtNYB6KUcqDgO6keeRXs72BsEfbUXs2R9wYgltbStZlwLrli1IMaGD1YQnf4XERtdYBsBunL6Iww68ljrp4/bS4MVgpSBo78y6Hm6bBnobJRBD0rTmYm7fQ43zs+wcWxzfCVLQUkRjyjv+CuD/ujGed5dd8R/4mXE9edXgl3b7ex4lla2P3C874W/jDBl/sNzDDwAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOS0wNS0yOVQxMzo1MDowNCswMDowMEYCC0UAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTktMDUtMjlUMTM6NTA6MDQrMDA6MDA3X7P5AAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = QubitCircuit(1, reverse_states=False)\n",
+    "q.add_gate(\"RY\", targets=[0], arg_value=pi/2, arg_label=r'\\frac{\\pi}{2}')\n",
+    "q.png"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Rotation about Z-axis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2], [2]], shape = (2, 2), type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.707-0.707j) & 0.0\\\\0.0 & (0.707+0.707j)\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2], [2]], shape = (2, 2), type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[0.70710678-0.70710678j 0.        +0.j        ]\n",
+       " [0.        +0.j         0.70710678+0.70710678j]]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rz(pi/2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAH4AAAAYCAQAAACWh4FEAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NMhG5jyRuAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAihJREFUWMPtlz2O1DAUx38PbYmEUm+BZKBGyBwhc4RcIRwhuQBS5ghMhxDN5giTK7jYGikSBQXNuuAAj2Ly4clEQquxdxjBS+M4zvP7v6+/LUpMkS+84VdUlbPc8lG/xlR4E9nAH3zWLg12afgZV+OzNIZeh/wHf1kRszqbSZZ659g1vwBANQw9nbrVNRW7abUdJp169VLJTv3VgldPLcp7dZJRSakfTqAXuANAsRQYegw9PR7YUVGntA+N+tCQH71bHoZRhmJP1u+nUaZQKjTB1yr8Y6n7/Cd1zeeMxFfgl4kvlmlGvWQYsUcLOoqUxqUGP8CTnILNimtCd5S09ATw1WH/tME5krTmgZxeGsDoZuVrRtDQdAuwcFHSjp+221vQGkD2UuruZIEdi0IsTTDvdGx0abu9fMKcr2aS13xnPt7OFZ/NMZQcB+ohqHjHZlVfGPm3bOQhoq3u5pR+zhFp+Ba8zg3NUoNYdVJgyWGNxMRQ0h9lSBj5e7q494ZkDU+sNOQYyQFwZFLgQVu29ENat+RH0AutQZpgxj1u10dKWp6fWZwcMzB/oYz8zV2wpjhw/HgyuH6eH13stdP+EF2s7CcKa2WKvbZag5TMaW80aeRTU93SCf1xrWsrlbj5BC8WM3Z6aRIfbi9/q9PtzDYH6IdckIzE15onj/wqfDdBv6OXEk8H6tNy/F8CPnDCq6fd8eJpf0n5p8HHTvsXvJNUtr7keVyFvwHWkH+CDbQsbQAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOS0wNS0yOVQxMzo1MDoxNyswMDowMLtAEUYAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTktMDUtMjlUMTM6NTA6MTcrMDA6MDDKHan6AAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = QubitCircuit(1, reverse_states=False)\n",
+    "q.add_gate(\"RZ\", targets=[0], arg_value=pi/2, arg_label=r'\\frac{\\pi}{2}')\n",
+    "q.png"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### CNOT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[1. 0. 0. 0.]\n",
+       " [0. 1. 0. 0.]\n",
+       " [0. 0. 0. 1.]\n",
+       " [0. 0. 1. 0.]]"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cnot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFwAAAA2CAQAAADgiTbvAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NMi2W4FjpAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAVNJREFUaN7t2r1pxEAQhuF3XIBhrwQZnPsncAG6EtSCXMK5BLkEuQRdCbrABQicG3Q4N5zAsWEcnE4Gc+EMrGE+BRo20D4ss5toRbGPJEYSAHu9cpgAEFoK86+uuF3qV77t2boWpxU/zOWkK4cJgAuPj+rE45E9vx3isuIAkthR6uQFd1lxAJ04+LEd4d4JeMADnmkCHvCAZ5qABzzgmSbgAQ94pgl4wAOeaQIe8IBnmoAHPOCZxgkupTQ8SCPlP4JLIT01ez7YU0sv9n+uAdT4ITFSKQq9olAxkqxnUQd4x2au+vldn6qM4RQMS71wGSis4dY9XrI7M7qlMt9Jxtc+7vnifa5veJuray4ZLNm6tm6VivZMqzTH7Zpxjyu/Z8iyOZPHuWJ/jr/Q/hnZsLW/R2EO12cm6eR4IwtJ0nGnT+bLY98qikLNSMcnHePpVLd+fgCSXkeWsEDYvwAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOS0wNS0yOVQxMzo1MDo0NSswMDowMGQ/DgsAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTktMDUtMjlUMTM6NTA6NDUrMDA6MDAVYra3AAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = QubitCircuit(2, reverse_states=False)\n",
+    "q.add_gate(\"CNOT\", controls=[0], targets=[1])\n",
+    "q.png"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### CSIGN"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 0.0 & 0.0 & -1.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[ 1.  0.  0.  0.]\n",
+       " [ 0.  1.  0.  0.]\n",
+       " [ 0.  0.  1.  0.]\n",
+       " [ 0.  0.  0. -1.]]"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "csign()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAGEAAAA9CAQAAAAXQ8+kAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NMwW6TsFSAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAadJREFUaN7tmjFSwlAQhr/nUIIMjoVWaLyADFegs7FBO0s4AhyBK0BpQ0Fjb44gB7CQGSo70thYrYUREwsseKsLs18K8nYy75+P95IwwyLoHXRZIbzQ1kwJtGmgQ5V7agC8cqeUgaQVOmoKzVwATrniXSklDaI0M4QGq/w0kyO1GA70ppaM/qdA/qkWpHpwzZSGbobiKgDwxlIy3QhthT/AFSzgChZwBQu4ggVcwQKuYAFXsIArWMAVLOAKFnAFC7iCBVzBAq5gAVewgCtYwBUsUIk7XbjkuFRo0QydUqUqD5Ez4/7vHKbAslCoc8Jz6ZJbOY+rEHkVWJJKulGyHTlxH+6FPVCIvZEKhFFhMJfZDirQoy8zCAlP3OjFaG6kSf7Nj3+7xbdDcxVmAKFLmwvFFCohbldYk+rXqcwhNBgzLDWS1H686rYkflfY2bcCAAPmMilVDomqQBq7/2hEpzDqsCIRBHrr2uNu9SONmcgCQK3/D9UnUhiRyRAgJJoKak+kkDBglr/eeky2nO4/FGRBWA+GegJ78RtpDxRib6Q6rbD5iuhNtx8ml10sQQgmdgAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOS0wNS0yOVQxMzo1MTowNSswMDowMA+3a88AAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTktMDUtMjlUMTM6NTE6MDUrMDA6MDB+6tNzAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = QubitCircuit(2, reverse_states=False)\n",
+    "q.add_gate(\"CSIGN\", controls=[0], targets=[1])\n",
+    "q.png"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Berkeley"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}0.924 & 0.0 & 0.0 & 0.383j\\\\0.0 & 0.383 & 0.924j & 0.0\\\\0.0 & 0.924j & 0.383 & 0.0\\\\0.383j & 0.0 & 0.0 & 0.924\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[0.92387953+0.j         0.        +0.j         0.        +0.j\n",
+       "  0.        +0.38268343j]\n",
+       " [0.        +0.j         0.38268343+0.j         0.        +0.92387953j\n",
+       "  0.        +0.j        ]\n",
+       " [0.        +0.j         0.        +0.92387953j 0.38268343+0.j\n",
+       "  0.        +0.j        ]\n",
+       " [0.        +0.38268343j 0.        +0.j         0.        +0.j\n",
+       "  0.92387953+0.j        ]]"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "berkeley()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAKwAAABBCAQAAADm4ocPAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NMyYYKbAgAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAvZJREFUeNrtnDtu20AQQN8EalIZ7NIF2DaVwQO42RyBV5COIJcpqSNQR4iPIB7B6pJWSC4QNgZSTgrSFCVRiuHsUHAwzw29mtnPE7VLWmuKkhKp+MTvpFVOw3u+6yJlhbPEHWz4ovWEQhIhkZi2xnfXHtL/ios1wsUa4WKNmMmSLGF9d3y79pBexQfupExY325GnVTsR56mdpKEJ36Q8mqmmek2Zf8kvlmxP9NeJvoca4SLNcLFGuFijXCxRrhYI1ysES7WCBdrhIs1wsUa4WKNcLFGuFgjXKwRLtYIF2uEizXCxRqReovREQdbd7b6cFIGsCb0JTtq3R1E1VpD+w2q3l/K1fuRNtuYSNhHyJwArNt2zNCkP5TEo5IMJVMUljx2R7EvC1QU+ygyKsouM6CE7njO8mzuIK6LPo2Zo+R9jzbtqwcZZWIT1mIVtD967KXp4PXlsIQMpTiMIn8uuZx7MWbD1/5Nyk7ik4udeo5thr9ILjkcfp+vzXGKBEI7ifwt92LMgkIiSBhrIz2TiZVMKmpdDUsoyOBwZ4OUrIYaZU45onU091KM7lhRScZc11OM13jx6obYLiZbcsmezxaJZO2S0keVQAbDDcBSsCOX5fANGcsdbfMoRu+loGLFNEw6x1ZshmVEotJm9PNptZ/t2gWHyK/h4nQ+V+kXu5OYrnebM/1OPsdOcsb2NIcXQt2mnnAUkw8itqC1rKn4fHRCjOVCMTwjz8RMwrSLVzhdbOT0Q90tMQNWBFmeVjeSG14QMwmT3CB0GyQDDQuQSNGXQcFDH1VrzZq5RILsuqhaa3IalpKxJozk7ksizVj9XV/m5AQpzW8N2tYS/9dMK+Lf6sjI2U0x+EGbkfh855aGaefYF6FN0p2qV8L/CGOEizXCxRrhYo1wsUa4WCNcrBEu1ggXa4SLNcLFGuFijXCxRrhYI1ysES7WCBdrhIs1wp8J0+LPhDHCnwljhD8T5q3gYo1wsUak3rBxw61ce0yv4ZabtBX+ATeXbhfDh8yzAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE5LTA1LTI5VDEzOjUxOjM4KzAwOjAw4O8N7AAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxOS0wNS0yOVQxMzo1MTozOCswMDowMJGytVAAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = QubitCircuit(2, reverse_states=False)\n",
+    "q.add_gate(\"BERKELEY\", targets=[0, 1])\n",
+    "q.png"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SWAPalpha"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & (0.610-0.488j) & (0.390+0.488j) & 0.0\\\\0.0 & (0.390+0.488j) & (0.610-0.488j) & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[1.        +0.j         0.        +0.j         0.        +0.j\n",
+       "  0.        +0.j        ]\n",
+       " [0.        +0.j         0.61029202-0.48768399j 0.38970798+0.48768399j\n",
+       "  0.        +0.j        ]\n",
+       " [0.        +0.j         0.38970798+0.48768399j 0.61029202-0.48768399j\n",
+       "  0.        +0.j        ]\n",
+       " [0.        +0.j         0.        +0.j         0.        +0.j\n",
+       "  1.        +0.j        ]]"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "swapalpha(pi/2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### FREDKIN"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  1.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  0.  0.  0.  1.  0.]\n",
+       " [ 0.  0.  0.  0.  0.  1.  0.  0.]\n",
+       " [ 0.  0.  0.  0.  0.  0.  0.  1.]]"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fredkin()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### TOFFOLI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  1.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  0.  0.  1.  0.  0.]\n",
+       " [ 0.  0.  0.  0.  0.  0.  0.  1.]\n",
+       " [ 0.  0.  0.  0.  0.  0.  1.  0.]]"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "toffoli()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SWAP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[ 1.  0.  0.  0.]\n",
+       " [ 0.  0.  1.  0.]\n",
+       " [ 0.  1.  0.  0.]\n",
+       " [ 0.  0.  0.  1.]]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "swap()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### ISWAP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0j & 0.0\\\\0.0 & 1.0j & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[ 1.+0.j  0.+0.j  0.+0.j  0.+0.j]\n",
+       " [ 0.+0.j  0.+0.j  0.+1.j  0.+0.j]\n",
+       " [ 0.+0.j  0.+1.j  0.+0.j  0.+0.j]\n",
+       " [ 0.+0.j  0.+0.j  0.+0.j  1.+0.j]]"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "iswap()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SQRTiSWAP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.707 & 0.707j & 0.0\\\\0.0 & 0.707j & 0.707 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[ 1.00000000+0.j          0.00000000+0.j          0.00000000+0.j\n",
+       "   0.00000000+0.j        ]\n",
+       " [ 0.00000000+0.j          0.70710678+0.j          0.00000000+0.70710678j\n",
+       "   0.00000000+0.j        ]\n",
+       " [ 0.00000000+0.j          0.00000000+0.70710678j  0.70710678+0.j\n",
+       "   0.00000000+0.j        ]\n",
+       " [ 0.00000000+0.j          0.00000000+0.j          0.00000000+0.j\n",
+       "   1.00000000+0.j        ]]"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sqrtiswap()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SQRTSWAP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & (0.500+0.500j) & (0.500-0.500j) & 0.0\\\\0.0 & (0.500-0.500j) & (0.500+0.500j) & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = [4, 4], type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[ 1.0+0.j   0.0+0.j   0.0+0.j   0.0+0.j ]\n",
+       " [ 0.0+0.j   0.5+0.5j  0.5-0.5j  0.0+0.j ]\n",
+       " [ 0.0+0.j   0.5-0.5j  0.5+0.5j  0.0+0.j ]\n",
+       " [ 0.0+0.j   0.0+0.j   0.0+0.j   1.0+0.j ]]"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sqrtswap()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SQRTNOT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.500+0.500j) & (0.500-0.500j)\\\\(0.500-0.500j) & (0.500+0.500j)\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[ 0.5+0.5j  0.5-0.5j]\n",
+       " [ 0.5-0.5j  0.5+0.5j]]"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sqrtnot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### HADAMARD"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}0.707 & 0.707\\\\0.707 & -0.707\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[ 0.70710678  0.70710678]\n",
+       " [ 0.70710678 -0.70710678]]"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "snot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### PHASEGATE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0\\\\0.0 & 1.0j\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[  1.00000000e+00+0.j   0.00000000e+00+0.j]\n",
+       " [  0.00000000e+00+0.j   6.12323400e-17+1.j]]"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "phasegate(pi/2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### GLOBALPHASE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0j & 0.0\\\\0.0 & 1.0j\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2], [2]], shape = [2, 2], type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[  6.12323400e-17+1.j   0.00000000e+00+0.j]\n",
+       " [  0.00000000e+00+0.j   6.12323400e-17+1.j]]"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "globalphase(pi/2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Expanding gates to larger qubit registers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The example above show how to generate matrice representations of the gates implemented in QuTiP, in their minimal qubit requirements. If the same gates is to be represented in a qubit register of size $N$, the optional keywork argument `N` can be specified when calling the gate function. For example, to generate the matrix for the CNOT gate for a $N=3$ bit register:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  1.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  0.  0.  0.  1.  0.]\n",
+       " [ 0.  0.  0.  0.  0.  0.  0.  1.]\n",
+       " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  0.  0.  1.  0.  0.]]"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cnot(N=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFwAAABeCAQAAAAELrvYAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NNiCMPeFQAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAZNJREFUeNrt27FNw1AQxvH/MQCS09IFiR5CwQDJCF7BjBBGCCOEEZwRTMEAkeiRHNFQIcUSNdJRxDECpULvxIv0fS58cmH/FN275r0YS8bE5Iy3oDfjM/Oodwfn5L8Bgh9LBBdc8EwjuOCCZxrBBRc80wguuOCZRnDBBc80ggsueKYRXHDB/xQrbWturU2i4CHbhVbQUgCw8fMgeMgG7YiroX7iMz07aIPWCrZ92fko4AME9bh33O7Y/T0gYVviVvDI1LsoeNg49I5tHFtzXHDBs43gggueaQQXXPBMI7jggmcawQUXPNMILrjgmUZwwQXPNIL/jE1twY0tbHpEcBtbQ8WGVzZU1ljMX4s98UVBS+k4NI5DSUuR+iseAK+Z91XT36t9lTGcMeuhHrisGaeGp+7xKY8Hnq4ok6+kxMc+rvngpa8vee6rC05Zp2T7LHWrlCwPtMpit1wz7nHne4YMi7OImCvp5/gDy19P5qzSn6NIDvd7OqttdyILK6xm4nfJf570reI4VLTUvFPT7qd66usLz2dPOb0MhXkAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDUtMjlUMTM6NTQ6MzIrMDA6MDCitpnmAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTA1LTI5VDEzOjU0OjMyKzAwOjAw0+shWgAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNSAFXAs5AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = QubitCircuit(3, reverse_states=False)\n",
+    "q.add_gate(\"CNOT\", controls=[1], targets=[2])\n",
+    "q.png"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Furthermore, the control and target qubits (when applicable) can also be similarly specified using keyword arguments `control` and `target` (or in some cases `controls` or `targets`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = [8, 8], type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[ 1.  0.  0.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  0.  0.  1.  0.  0.]\n",
+       " [ 0.  0.  1.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  0.  0.  0.  0.  1.]\n",
+       " [ 0.  0.  0.  0.  1.  0.  0.  0.]\n",
+       " [ 0.  1.  0.  0.  0.  0.  0.  0.]\n",
+       " [ 0.  0.  0.  0.  0.  0.  1.  0.]\n",
+       " [ 0.  0.  0.  1.  0.  0.  0.  0.]]"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cnot(N=3, control=2, target=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFwAAABeCAQAAAAELrvYAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NNi8cgvzBAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAaVJREFUeNrt3DFKA0EUxvH/E0sV1s5KSGEvscgBNpV1Wst4BD1CPEIsLTdH2BzAImAvrNhZCFmws3oWmUQUy3kwwvdtsY8tXn4MM9NsZnEiLiascTqGMf0dY0hF7hzwwCEAb1xl7w74cp86AH6a2HDCJZ8B8qV5QFerWKey9+OAHwD2Ipp6z/WGne4BCRlxAKtYUnsfBQ8ZcQDvWcexA+HREVxwwQuN4IILXmgEF1zwQiO44IIXGsEFF7zQCC644IVGcMEFLzTGnEFQ7xGPUWwfh70uBGt9HNb8/04VwQUXvNAILrjghUZwwQUvNIILLnihEVxwwQuN4IILXmgEF1zwQiP4z1htM0Y2s/ofwW1gLVNeeOWFqbUW8x41+2nlio6J49Cm08sdVcCp6OwNG25S1ab7dFsVDGfAalfvuKwY5IbnnuM1yz+eLphkX0mZ/4RwwQfPqT7nKVVnHLHKyfZx7qkyYf7HVJltlmvBc9z53kN2i7OK2Ffy7+P3zH89uWGR/9h1drjf0Vtj6esKVlnD0G+zD0/+qeI4TOloeKeh2+7qua8vGP6mebAe7w8AAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDUtMjlUMTM6NTQ6NDcrMDA6MDD6S79YAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTA1LTI5VDEzOjU0OjQ3KzAwOjAwixYH5AAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNSAFXAs5AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = QubitCircuit(3, reverse_states=False)\n",
+    "q.add_gate(\"CNOT\", controls=[0], targets=[2])\n",
+    "q.png"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup of a Qubit Circuit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The gates implemented in QuTiP can be used to build any qubit circuit using the class QubitCircuit. The output can be obtained in the form of a unitary matrix or a latex representation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the following example, we take a SWAP gate. It is known that a swap gate is equivalent to three CNOT gates applied in the given format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFEAAAAoCAQAAAAsq960AAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NNjMIg6COAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAALxJREFUWMPt2LEJwmAQhuH3JGAjQhxBsLXJLBYWtq6QdLap7cwK2cI+EwQCFpaSEc5GdIETrvje6q8+Hv7yjBtbotqwZ+QZtge9d+Zha1bSsgY/BhKBRSiw4cHd2qREahqfgZHezpHEImrIm+9rYIgkxv3i3xJRxCyJKGKWRBQxSyKKmCURRcySiCJmSUQRsyRiKuLvNmul1SmJ9B/kipYukhh5jq84sGTHyedIYmEVZdjaiwtXKovzTT69AQgTIQ7cyJt/AAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE5LTA1LTI5VDEzOjU0OjUxKzAwOjAwVTGK/AAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxOS0wNS0yOVQxMzo1NDo1MSswMDowMCRsMkAAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "N = 2\n",
+    "qc0 = QubitCircuit(N)\n",
+    "qc0.add_gate(\"SWAP\", [0, 1], None)\n",
+    "qc0.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[1. 0. 0. 0.]\n",
+       " [0. 0. 1. 0.]\n",
+       " [0. 1. 0. 0.]\n",
+       " [0. 0. 0. 1.]]"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U_list0 = qc0.propagators()\n",
+    "U0 = gate_sequence_product(U_list0)\n",
+    "U0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMEAAAA/CAQAAADz02R+AAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NNjcP7mSXAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAy1JREFUeNrtnL1qFFEUgL8jtgqTRxiDrWhSpDHVpLeZ4BNsHiE+wuQNnLyAMCsItrOFRLDaRRAsFHdRSCdsIGgnHItMNr/V5p4cR863RW6mOPee/ebM3FvsESXw5Y73ApZFMqllKq/lizQylcJ7PcvTUwWS0zLTB7zkjW6zTSWV95qWpacKqNnTvdN/dKLrFH2tBCMFUspcVKayZhOdIx1euriDSR3YZgJGCiSjJgNyGpNVr3FZADoByXqXCSDU5MmjrvBkMX7Hn+TxN/nQRV1hhW/d1Q0OOexZJugWavAhWwznJvFrim5UUC2utuR9y0RRmweRHrEDwOnf1Ey48uqVjFxnZpkcG2UCGJlVyJiQmcWesnaxCmjYNZvtFc+sviejKujun7kemcXeoTnbhEomFZxtUpPP9oNfNrEB7tqFtkRHsk0tE36zKhUlQ932XtOy9PVodnIcG7LKI2Zs6Qvv9SxPT6vgBB0JFLrvvY6b0dsq+H8IBe6EAndCgTuhwJ1Q4E4ocCcUuBMK3AkF7oQCd0KBO6HAnVDgTihwJxS4EwrcCQXuhAJ3QoE7ocCdUOBOKHAnFLgTCtwJBe6EAndCgTuhwJ1Q4E4ocCcUuBMK3AkF7oQCd0KBO6HAHaNfXEpBwYZUjHTkneINM8kpeM665IzSN1gAkyqQXFoGzPjOjIG0kr7Ty60hu7TkfOKAnFYGJpOY9IcoFYVWUSiZWvWiuNiJxSB6RUOmUFEoZDQWs6V/ENXsn++YpUPJaNiyuk/tkIJC189lciQ7jGWok8QTJb5vcsaLcbsYjdN3Cuoq7Bg97cqSPHqz6HpULUZl+jpI/S4ouO71O6RMPA9d07J7GLZfu2YrMSJ5E8LUjdHWOeZrN37Mx270kPuMk39F1k3LnvK+G60yZ96NNzlIOUnyxmiU1Nc8iKqTF3Tiuazbry22EeceRPlZVv/og0iHFJf7JEpGicHpwLz92pCrm9CBQSbJ751dmotVQGW3cSSjMG2/lp+vAtYsNtgWS6+73XTb7aWTl+5tfShPzjjduWDXZu9ls/QBUxp+0jC1atp3SxJyWsZ85i1Tapt6+wsYAFhmepTpRwAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOS0wNS0yOVQxMzo1NDo1NSswMDowMKF+ru8AAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTktMDUtMjlUMTM6NTQ6NTUrMDA6MDDQIxZTAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc1 = QubitCircuit(N)\n",
+    "qc1.add_gate(\"CNOT\", 0, 1)\n",
+    "qc1.add_gate(\"CNOT\", 1, 0)\n",
+    "qc1.add_gate(\"CNOT\", 0, 1)\n",
+    "qc1.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[1. 0. 0. 0.]\n",
+       " [0. 0. 1. 0.]\n",
+       " [0. 1. 0. 0.]\n",
+       " [0. 0. 0. 1.]]"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U_list1 = qc1.propagators()\n",
+    "U1 = gate_sequence_product(U_list1)\n",
+    "U1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In place of manually converting the SWAP gate to CNOTs, it can be automatically converted using an inbuilt function in QubitCircuit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMEAAAA/CAQAAADz02R+AAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NNjpxXxgqAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAy1JREFUeNrtnL1qFFEUgL8jtgqTRxiDrWhSpDHVpLeZ4BNsHiE+wuQNnLyAMCsItrOFRLDaRRAsFHdRSCdsIGgnHItMNr/V5p4cR863RW6mOPee/ebM3FvsESXw5Y73ApZFMqllKq/lizQylcJ7PcvTUwWS0zLTB7zkjW6zTSWV95qWpacKqNnTvdN/dKLrFH2tBCMFUspcVKayZhOdIx1euriDSR3YZgJGCiSjJgNyGpNVr3FZADoByXqXCSDU5MmjrvBkMX7Hn+TxN/nQRV1hhW/d1Q0OOexZJugWavAhWwznJvFrim5UUC2utuR9y0RRmweRHrEDwOnf1Ey48uqVjFxnZpkcG2UCGJlVyJiQmcWesnaxCmjYNZvtFc+sviejKujun7kemcXeoTnbhEomFZxtUpPP9oNfNrEB7tqFtkRHsk0tE36zKhUlQ932XtOy9PVodnIcG7LKI2Zs6Qvv9SxPT6vgBB0JFLrvvY6b0dsq+H8IBe6EAndCgTuhwJ1Q4E4ocCcUuBMK3AkF7oQCd0KBO6HAnVDgTihwJxS4EwrcCQXuhAJ3QoE7ocCdUOBOKHAnFLgTCtwJBe6EAndCgTuhwJ1Q4E4ocCcUuBMK3AkF7oQCd0KBO6HAHaNfXEpBwYZUjHTkneINM8kpeM665IzSN1gAkyqQXFoGzPjOjIG0kr7Ty60hu7TkfOKAnFYGJpOY9IcoFYVWUSiZWvWiuNiJxSB6RUOmUFEoZDQWs6V/ENXsn++YpUPJaNiyuk/tkIJC189lciQ7jGWok8QTJb5vcsaLcbsYjdN3Cuoq7Bg97cqSPHqz6HpULUZl+jpI/S4ouO71O6RMPA9d07J7GLZfu2YrMSJ5E8LUjdHWOeZrN37Mx270kPuMk39F1k3LnvK+G60yZ96NNzlIOUnyxmiU1Nc8iKqTF3Tiuazbry22EeceRPlZVv/og0iHFJf7JEpGicHpwLz92pCrm9CBQSbJ751dmotVQGW3cSSjMG2/lp+vAtYsNtgWS6+73XTb7aWTl+5tfShPzjjduWDXZu9ls/QBUxp+0jC1atp3SxJyWsZ85i1Tapt6+wsYAFhmepTpRwAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOS0wNS0yOVQxMzo1NDo1OCswMDowMMCpzy8AAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTktMDUtMjlUMTM6NTQ6NTgrMDA6MDCx9HeTAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc2 = qc0.resolve_gates(\"CNOT\")\n",
+    "qc2.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2], [2, 2]], shape = (4, 4), type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[1. 0. 0. 0.]\n",
+       " [0. 0. 1. 0.]\n",
+       " [0. 1. 0. 0.]\n",
+       " [0. 0. 0. 1.]]"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U_list2 = qc2.propagators()\n",
+    "U2 = gate_sequence_product(U_list2)\n",
+    "U2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example of basis transformation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeMAAACSCAQAAADcd2pjAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NNwigk3jrAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAADLFJREFUeNrt3b9v7FZ6xvHvG6j0wuHNAnFyi7ug7WCRIsYNXS6wKag2HY1t0lJY5A/gIHWKEVKkSBFousViG7FOpWkMBAgQiIWTZgHnErsIDBgBcumN3aQI3hT8MRxpJF1fcYY6c5+PmtFwxCFHenR+8PAcc0Tejv0nvz74m770H8593k/PydwHIAH7tZ8e+i3tau6Tfop+b+4DEJHHUoxFgqdKtRyUxV6/+TaLwJs9Hs2P+AlfH/xD+IB/9t9MuUPFWCZiEUX3sGHt1c7XFKzu2UXOottT4msAb6yw1R6D/BP+ms8P/lH9FPjNlDtUjGUi3rAw51OvLKKw3M9uvsIyqrsjaRERgOVAY1eUvgJWFG249+JrPvf97f2uM11OXQNQjGUyltB4Bd7YOa9tdatEzu/t2c5YgcXEvgCDC1bgjTWW7C7bpacuLplOyrp7lLWBHrOE+8PYhjWisAi8JLIUgDXZ3Cf21Kk0lul0QbWUjNvlbtrH2JakRNRENFRtpdZiGgCvMADLaLr2cWXLuU/sqVOMZToptS2BeGflOWqDahmlLyz3lRV+PmzNbnR+5aMWcTT3iT11J3ZBvKd9P+eruU9vxzH9D9/OfRBHcw4/Hn9jCXQl65XlfrtHOmmr3F6CJdQWM768tHWxyZZdB1dr3C320aTjuJ7xXzN8bp9waq8n3F95crs/UeTN3AjUpmUc9eWnpVTDld9xyzj3M0s38dxuN1tG5aXF0EV7XBr/x5QDQC0lneGD+4K1rx+/mw11cclUNlFMqMASy0gphqvJA4u6GuAmQhnlsDWl9hJIhvJ5jwNAjoNiLBOwxJakxF3fckVkGY2XnFMP12XLIbZ5V24nmz3015Mt5pJrc3OWwzO63PQAdXHJBLyiGnVJnZJQe20Jsa/6q75eWV8ur7wBX1tX2lq2CarXPLux81FJLbupNJbJeeNrry0mI7GrUZlbtqV1X/IOlebE7wtqrMEfD1FpLHvi9c1BlF5aYbeGY9q9l5NsucehmEdDpbEckJ/vuLwZ3X27hEXs88aIo6HSWA7qdgX57hsXwRv1Ur8JlcYiwVOMRYKnSrW8veczTHD348fv4vgoxvLW/E/nPgJpqVItEjzFWCR4irFI8BRjkeApxiLBU4xFgqcYiwRPMRYJnmIsEjzFWCR4irFI8BRjkeApxiLB0x1OIjtZREZMw4qUbmZtX1jeP4J2balupYyEtF/KZmsS+/IgEwK6vvT1zn6Rsrz1XMK143BJ5DgsWTos22cdCl53jyIu2tc4LHk12keEdz9dcNW/Zti6JJ32PFSpFtnilX8KlhB1k/m1ZWxJ0s3hWRFZWyI3W8uuxzZM5etNP42vnxOR7/uYFWOR3brYesMavKLu1lmOqdpHNkyEbwkl5R3rMDf7XxFSMRYZWGSFXVjSrYPxyi6tsLhbNq1fvCbaBHYoi1Ovdi+nbgnJ3RP4TkUxFtnI/LxfD9JPOQcKrrvKcklmkcXUlCS2Pd92BJTDGlYA2NKWVpDy4X1T+E5DPdUiG6VFJP2ipW3Ps11Q8Bl4ZTXtAnNYRWZ1vxCsZdSWAmsyNgueTrz46X1UGosMvOkXfrN0KFkXw0oXmzUhS7JRlTrxla99zeqO1vHeKcYiYzkra8PYRzairxRvOrHK8aKu/coWXoLNEmRVqkXGmiGgkRVUQNYvBueVVe3aj15b1VafLSUntsrXYEsaCktYkwKZcahqtfncH5vIbCwl9RsrNlrsdbvOozeWshXFdhuARW+/RJwtp243qzQW2dIGtRu8sd61bbP9qVDbWCR4irFI8BRjkeApxiLBU4xFgqcYiwRPMRYJnmIsEjzFWCR4irFI8BRjkeApxiLB060RM7Ff8tXB3/R9av+7uc9cpqcYz+VjfnHw93xJ/PidyNOjGM/l28PN1NQz+IO5T1v2QW1jkeApxgGx+Ptttcj2PtG5PAWqVD8JFlF0DxvWuxfvsuKBacvzds6ozRSt3lhhq6c1T4Xsw15ibBEZKT/lcyr0Z/QGvGFhzqdeWURhuZ/dfIVlW+sF3WLdJOmWA41dUfoKWFGwQI7cHirVlnBNzDn/xjkR1+OZ9OUultB4Bd5wTm7JrRfkD3SJZazAYmJfecmKdtHOhmbHvuTITB5ji7nkM194BV75gs+40B/SG0iH9QayNtBjlvDQKrmJV0BEYRF4SdT9+1zPNQW6HM70pfEFi/EfoVeccTH3aQagC6qlZJze2pr2MbalXdsru7Jru2qXyQawuJ3y3Cs3b8Aymq59XKF/okdv4raxxURebj/na6stOcia6yFLqW0JxH66Y2vUxtQySl9Y7isr+rXtga5KPZKPWsTqrT56J5ZM+mv+OV8ObeFnw6P/42/sH+c+VQA+4Du+m/sgAHg2/sYSaKc9tyvL/XaPdNJWub0ES6gtZnuVvni8ap8tuw6u1qZj7D1ePJGeio/5cu5DAOAl78/wru/z0qbcX31COmmM/4z/Hta+eTY8es4f8TT+fF7wDb+b+yCAGzEetYz7HueEpl29wBvYahnnfmbpKJw3Ws6WUXlp8TA5+ub3+x4/eiK/h0/4Yu5DAODFLO/6+/z5pOPp1idbVbNHszVZv5iGJcOjC/7hZlX7XXej228TxIQF2M/5Vy44tRy2q8sWdeOi09ESnBnDb9FSaq+AZPjEN4H/ms9dl59GLJ3l39pvp178ZeIuLl+T3hxNZBGpQnw3S2xJOixxXRFZxr8QUzFUpkdLcubdM1v/BvoryhZzybW5OcvhGfVKHL3ph38suLjR03rJpCX+sfGKatQhdUpC7bX9jDVDm9cr60d5rbxpuw37H7BsE1Svb1TW6dfrlWM2+QUnL6nsuq8yWmLXVL563D7fJd742mugJrF81JFVtqV1X+6OurSSe+s6sa4RHL89DMb0haUsLeaP7RU1i8PfkHcc/NyWm/avl1bYjuGY99/8YEsNxXwX7GVMta9Zg13tvAIqb8AiYsupx+Wsn+8cyxXdfcOERRrR/oA/5C9nGGP4nH+fdoe6w+lJ8mZXKbqreuz1vXtRiO/lv+JXcx/DFHS/sUjwFGOR4CnGIsFT23guP7Srg7/nD2aYVFcOQDGeib+c+wjkeKhSLRI8xVgkeIqxSPAUY5HgKcYiwVOMRYKnGIsETzEWCZ5iLBI8xVgkeIqxSPAUY5HgKcYiwVOMRYKnGIsETzEWCZ5iLBI8xVgkeIqxSPAUY5HgKcYiwVOMRYKnGIsETzEWCZ5iLBI8xVgkeIqxSPAUY5HgKcYiwVOMRYKnGIsETzEWCZ5iLBI8xVgkeIqxSPAUY5HgKcYiwTuZ+wDehv2Sr2Z42+f+V3OfucguQcaYj/nFDO/6t3OftshuYcb4W18f/k2tmPu0RXZT21gkeO9MjC3+flstsmjuYxZ5M2FWqrdYRF/dbVh7tfM1Bat7d5Kz6PaVtBV2b6ywlTdzn53Iw44gxt6wMOdTryyisNzPbr7CMqr7AmkREYDlQGNXlL4CVhRtuEWetiOIMVhC4xV4Y+e8ttWtEjn303t3kLECi4l9AQYXrMAbayzZXbqLPCXH0TZO6XuuszbQY5bwUBTbsEYUFoGXRJYCsCab+9REHranGFtmr0ntlSUHOYsuqJaScbvcTTcxtqVd2yu7smu7smX3XEwD4JWbN2AZTdc+rjjM8Ys8yl4q1RZxQQTEXPLhAc4ipbYlEO+sPEd07WLLKH1hua+s8PNhe3aj+ysftYjVWy0BOLFiD3+qL4Z9xvb3/O/k+/9o/I0l4G0/85XlfrtHOumr3F6CJdQWU4+2xz76zpZdB1dr3DH2UV9+z+wF3/C7uQ/ikT7hi7kP4YjOYX3Ceg8xfo+fdY++5Z/2cNjbZe6mZdz3OEckvra065/ebhnnfmbpJp7bLWfLqLy0GLpojz+b18wwdmyHD/iO7+Y+iEf6LV/OfQhHdA71yX56Yu2MC6DhbB/DJu311rebICYswP6CP6G0axa3LxhZRDvQY9wpNlSvLaX2Cki87J4al8av5xgCeqSO4ZN8Quewpy4uX/GMUz4c4rAnltiSlLjrWa6ILOMbXxGz9nVb1aYkHX4g7z78UddVf0XZYi65Njdn0/mly00SAPO5j+BtDvpq93Vgi0ioaYCc2sv+qq9d+mf9K9rQWtcetqxtMd/xPsV4VNhd7yoyt6MY/tHzhjV0nXaxbS40lZb2Qyy7V/adWonfN04r1uAPCcFRxbg1upTUP1NaYTuGY95/84MtNRRTwnAco7ge5OfsusMpuvuGCYvQjRESiCMsjXfbVT0eXy++ta1BIZZAvCOlscgxU4xFghdmpfoHlj5+J9//Xec+bZHd/h8pDp/jWYqbFgAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOS0wNS0yOVQxMzo1NTowOCswMDowMGeLqnUAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTktMDUtMjlUMTM6NTU6MDgrMDA6MDAW1hLJAAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc3 = QubitCircuit(3)\n",
+    "qc3.add_gate(\"CNOT\", 1, 0)\n",
+    "qc3.add_gate(\"RX\", 0, None, pi/2, r\"\\pi/2\")\n",
+    "qc3.add_gate(\"RY\", 1, None, pi/2, r\"\\pi/2\")\n",
+    "qc3.add_gate(\"RZ\", 2, None, pi/2, r\"\\pi/2\")\n",
+    "qc3.add_gate(\"ISWAP\", [1, 2])\n",
+    "qc3.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.354-0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0\\\\(0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354+0.354j)\\\\0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j)\\\\(-0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\(0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0\\\\0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354+0.354j)\\\\0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j)\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[ 0.35355339-0.35355339j  0.        +0.j         -0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "  -0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.35355339+0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339-0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.        +0.j         -0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j         -0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j]\n",
+       " [ 0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339+0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339-0.35355339j]\n",
+       " [-0.35355339-0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j         -0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.35355339-0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339+0.35355339j  0.        +0.j        ]\n",
+       " [ 0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "  -0.35355339-0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j         -0.35355339+0.35355339j]\n",
+       " [ 0.        +0.j          0.35355339-0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j]]"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U3 = gate_sequence_product(qc3.propagators())\n",
+    "U3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The transformation can either be only in terms of 2-qubit gates:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABUcAAACSCAQAAADMHbNKAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NNwnXlEh9AAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAGAZJREFUeNrt3U+oLGla5/HfI3dhY5Vl3BG7mkJvG1WtjUg317gDA5Y4DnEWIjSKxO3ejBshD424GAQzcWsv8ujChQs5CcMg0jJzk8HFMMwiE6RQEOTEDG3PQM9038RCCqp7mBv9pxAaRh4XGZkZeTJPZp6TEfHmn++naer8uxHvm/Hm8z75xvu+YS7gYewf9LXWT/rUfzR0vXHM7P/o/dZP+o7+wP8kdM0B4HA9Cl0AHLGv+UXbp7RR6ErjyL0foNX29fXQ1QaAQ/YDoQsAAACAc0Y6CgAAgIC4WY9WWeyT3X9nkeRF6DLj3G1qtau/pdVuZ5/Uu/qw8dN8ihm7IdgXW5ic8qb+2v/+yMr8cf9yjSX+nP6x8RJvUvu7i3QUNbFI3fLLQmPP1/5NV4MNh+ioVx4p8bEkeWFdG5xK126JUv26/rOGm5IbtKmGVlu221NttQ15V7+l9xo/y+dFOhrC7+o/NX6OX5T093UdzKJWyvw51ZiO6vf13xov8Sa1v7tIR1ETL9Qz1zPPLVLXOn55+y8sU353J22RIkmyjqTCRhr6QNJA3WmSetws0rUijfWapJENdUW6cgj2bbWzdnuarbZBH+o9b/wVsiR0Nc/UN1q4tv06R9e9sDbKXG97/FbzJW6xNmLuKGpkiQrPJS90pc6axtqZjh7dIdNAslixD3yogfqS5IWK4+9ULNKNcr/wK33gV/62pJFFoUsFae9WK2UanGarBYD2kI6iPqlmHXc27eKrLFG+8V8nnkuK1LVI8qEiSyVJY2WhK7a3aw38avGt9zSe3yRGWPu12mm7Pc1WCwCtIR1Ffcqu21JlWt3bMZ117Na3G3tpI7uxkfXLn8UqJMlzNy8ky1SUM/FyNT7OZJm9MreXzYxoWaKomoxKkveUNTM+2mxdTtAerXbWbsO0WoTBOwxoAnNHUZ9UE+tLitduNB5NE07LNPSedXxg3UqSlt1aLtKpzL1r+LZ2Oa9TivVCbzfyuqy73TtUovG9jxW6Lqdnn1Z7u9222GoRBu8woBmP7FpxQ8d+Sx+Ert6aMn1X3wtdiJOpw6er31giTadW28g6vroWuUy+fChZoonFqq4vX9osx/rlkpCp6kKSdxp4LtPjeeoQ21/q/9d+/Gf6ZnkLV3o6L/8zfd6+cXR1ebgnAR7Ouc5TixZLk/ZstUvtdkOr/awu7FXoiks6nKj8WN9q4SzHGC0e7nB6hndaOEfd76knLZT5aa3t8WkLJd6k7nfX1aPVlaTAbm41xsUYYDQL2JYqn+/BWJ2D1/FLS1VNCiq/tUy5Dy2Wyq6+Os70jfof8WiRZmGt8F9q4HXqKJ6tgbTRrPx2raE3MTraaF2On42W1snv0WqX2+3GVvsVjeu/1sfMUqX7H2WrI4wWp6CVRznX/J5qpcz/o872GPyB2bW/u5g7irosuuZEuWSJZUrVXV2yY1E5Ir/okDIN579NNfGhpGQ+7tTwlkhe6LI8TzMfztYsa7FIaRMJSuN1OTX7tNpKu22/1SIM3mFAM0hHUQNLrK9UcXlLOldkmQof6kqT+d5ow3lH3ilHpCpLAWYjVhbrhW7MzbVY5LRtbfPefKDH+u9624f7H2vN0ScaLha/lK63bK2+T11+Tf+xqbqckv1b7azdhmm1CKPZaAGcK5YyoQaeK68s4rhQoolPLFHsA5tu4CTPbTbiNPBC8rGV40iWLbpun+jxrYNXRk4brEFhrxrcmP5KI+vPtr63SNfS7bX2NfpI77PJ/nb7tdpquw3VahFGw9ECOEuMjqJ2XvjYJxYrU2KjymjScDoONQvk89uaycZxhtiPfpzJC38m6cau9cyudaPcn4cuE5bdu9Vubrcn0GoBoD2MjqIhPrn9mEQfWtdWHri4efdN65/Kwxa9p56lutCQ5YOHa9dWu7ndnk6rBYB2MDqKFvnVmm3FortnUVo0vUV6Knysl6ywPjZrW+2GdntqrRYAmsfoKFq1egvTJxv+umB9MsJbd+P97nZLqwWA+2J0FAAAAAGRjgIAACAgbtbj4d4K8FyIT+9/CJy11wO02if6auhqA8AhIx3Fg/nPhC4BcF/+r0KXAABwGzfrAQAAEBDpKAAAAAIiHQUAAEBApKMAAAAIiHQUAAAAAZGOAgAAICDSUQAAAAREOgoAAICASEcBAAAQEOkoAAAAAiIdBQAAQECkowCAI2Hxmp9FFoUuF+rA1T1nj0IXAAAAi9Qtvyw09nzt33Q1WP2pF9a1gReha4C77HJtubrnjnQUABCcF+qZ65nnFqlrHb+8/ReWKb8jLRmoq17oGuAu268tVxfcrAcAHABLVHgueaErdSxZ+YOOj9f/Sy9UrPl7HIyt15are/ZIRwEAhyDVLCHJpslLlSXKN/zbsbLQxccGG68tVxfcrAcAHIYyJbFUmS5WfpsuEhbrK1WkiSIVyr0neW790MXHBpuvbeXqrl5bru55IB0FAByCVBPrS4p9XcISqZxZaJmG3rOOD6zrV5Xf43Btvrbzq3vHteXqngHSUQBAcJZI07EwG1nHV9dYJ7PbvT6ULNHEYk0qv2ft9cHaem3nV/eOa8vVPQPMHQUAhLeYXRjNxsIsslSy1CLp1tzCjo8VLyUpjJ8drm3Xdvnqrl5bru4ZIB0FAIS3WMySKJcssUiZcruR5rtWlizSdMP0tPJDxs8O177Xlqt7BkhHAQBBWWJ9pYptmoLkiixTIflAscY+9p6kYSVB6ZSjbfPtfyzeuDIbwex0batXd+XacnXPA3NHAQBBea68stH5hRJNfGKRRdMV15Z47rktxtEGXkg+tsX8wkzD0LXAOrtcW6lydVevLVf3LJCOAgAOiBfl+FhHkaTYZpsADS2dbpU+e3qPL1KW2Bk/OwJ3Xtv51V1zbbm6Z4F0FABwgJY2+pHkQ+va2gdJWp+HSB6X29eWqwvmjgIAjoJflctcllg0vcGL48bVPW+MjgIAjsS6m7ZesO76NHB1zxmjowAAAAiIdBQAAAABkY4CAAAgINJRAAAABEQ6CgAAgIBIRwEAABAQ6SgAAAACIh0FAABAQKSjAAAACIh0FAAAAAHxkNBA7M/0QesnfUMT/8PQNcfxsk/qXX3Y+mk/7l8OXfNDYpH+XF9p/bSf9V8OXfNzQM+Ac0U6Gsqn9Ketn/Op4tDVxlF7V7+l91o/6+dEOlrhhf2Yxq2f9iJ0vc8EPQPOFOloKN/z1jsUk/5F6GrjqH2o97zX9kktCV3tg/MqQPR4FbrSZ4KeAWeKuaMAAAAIiHT0iFh8v99aZFHoMgM4BJuiB7HjuNEz4BSQjh4Ei6xf/q97161J66rYeJDO/Fjp9Csv1CHsICy6ymbtEju2Rg9ix4GiZzh06+Lbocew+8Xk9mrTyNxRi5Qp1S/qPeUaeLH/EU+dF+qZ65nnFqlrHb+8/ReWKd/0SlqkSJKsI6mwkYY+kDRQV63P9Ts+1lGiX7CRxhr6JHRp9qpJrI5+VW+aNG56DppF6pZfFhp7vvZvuhpsPEhn2j4tUjItrxfWNaLGzrbHjm3Rg9hxP9ZRql+wF230bvQMYViqdP7NcBrbLFV6O6quj29hYthqmdeVeNeYHCIiNzA6aoluFOtKf6crRbqxdP9jnj5LVHgueaErddZ8Du5sSS4yDSSLFfvAhxqoL0leqGAhyGYW20iphvorXUoaWRa6RHvUpauRJvqS/oNyde1Fs59qvfCeuhp6TwNldr2mPLt3lZkiG9l0HGcwT3Oxg62xY1v0IHbszBK7UaKB/qqt3o2eIQQf60pdXXnPe0ptZJHkY0lL13tDfAsQw1bLvFriXWNymIhcezpqsV7oufc8lzz3np7rmma/g3S+dUs2DT9Vlijf8u8TzyVF6lok+VCzGzNjHXF61TyLNNLAn/tY8olf6Zm6x5qQWl+xnvlAH+r7PvQL5XrR8BnpKg/BxtixQ/QgduzIIr1Qzy993GLvRs8QhBfT/0t+pWg24eGWO+NbmBi2X5lLmQahInL9o6PX6lXfMp7rUtcPP9zZKMOKpcrW7PCXzoKO9e3GXtrIbmxk/dmvLZ7OHvLczQvJMhXlQHsuOvZNuhr6cPGtF3qu/mHP/FnPYmXqVT/3+pUKa/ZTLV3lIdgcO7ZED2LHPbzQVbUz91zPG+/d6BnCK7SmR9gS30LHsIeUWZrG5EARuea5oxYrqnbukuRjm1ji216Ec5dqYn1Jsa/rUKJpULFMQ+9ZxwfW9avK77Nbs0E6lXlBR5hatSjzt5d/4BMbrryetbBM14rspZ438m7o6GrlJsylRrp60NF2s2NXKVlfqSJNFKlQPt27dNFVysrXZ95VLjpUbLU5dmyLHsSOHVmsyG/FBc8tt7TRWdr0DIFZokSzObuRZSrU0aUXm+Nb2BhWKXO1xEsfX1Yj8iwmh4rIjyyptVF+UV+fz6Z5PP/qn/R79ifNV2YHb+ojfRS6EJKkx9VvLJHKLnpkHV9NhZLpKJQPJUs0sVjLC27i6gIc65fT1acWKcprenIgM3k/pa+HLoIk6TP67pr2+r5+2+pf0PSa/r1elxTrv9hvNFCXX9WXyho8rVznT9R6xZ/qjaXvd+oq906EHh9Iqz2c6PGxxZdbY8e26LFb7JBeb7QlNaPeMv8b/d+1vdvvWJ1lPoWe4fU6X5A7vKGntb7uH1v9kfU1fZXeXnzQ96FkXSUab41vq5lVvZHs8bofrpa5UuL7fnzZ/OGl3neXlD9SWms6+hn9v/nU2cfzr97SJ3QYHcoTfVvfCV0ISbeb0uKm52xxR6LCJ5JFXkhLA+wdv7S02lEsD8BbptyHFktlIFpc39f0yQO5Dp8N8MztdX5G0Zr2+oZ+ooHX6ck8SH9Cv6Lv1378N/Wz+tnyTIvr/EO11uRJ9Ztdu8q9E6HHB9JqDyd6VLv7ldhxn+ixc+yQfri5ltSYesv8L/Xja6LFT+qnaj3LKfQMP1zjse7yI/q5Wp8ltS6FXt2dpBqXtsW31QVD9UaytenoSpmXS3GPjy8bIvJUve8uqXjktd7Ks7Gy+bBvMv/qWn98+xb+ubs1MXgRNhL1JPui/lbXurCOtDyCZFH5dOG08tTqbHFD1lJNPJeUzF/xRTMK8ojHQ2aRRmvaa0ffqf91skhfKL8s/N81UpcyEFmqdF6XrM6aLG0lsjYRkixVXk6oX56S8PBE6Bu02mVL0eN27EgUqdg5euwaO6QPGmxJTam3zIm6a6JFX3/hNU7tOYWeoZVFPO/Xu5XdA8q8Mb5p3XhirZHsQa/yzh9fNkbkqVrfXVLtS5l8rHR1E1WlJKN3s8T6ShWXA9+5Isv0N4qVa/H5azgP3p3yJ0tNcTYsb7Fe6MbcXIuFCszavZMXKtbccOiogfbqRTmXp9Dlnodab7y6GYd11eSstmpXmU/Do2VK1V1TkkVnOZMtXmVLNfGhpGT+2Zx9R3ewNnYUyu8TPYgdu/Jcye0UwKJqO64XPcPxWBPfDjyGrS3xvC2Hicj1b4Pf0/WtRQ0vGl1McfQ8V16ZoXGhRBOf2Bc01nzo3PP5CumBF9PlYbN/YNkirPhkZQC/sWB5Inp6Yc+qS4Csf9eW7vvygQ2VbN71bY+jDy1bngdkiTp61sS5JEuUKVVRLuOYdpW55EMbKytHi4bK5unwtkQoMkmaTFsrXeVu1scOyZLdogex454udW0XS+/f6+a2wqdnCKccvc9MixFYS5VIlipWrMy2xLf2Y9hqmW+X2MeVMm/4+BIqIteejvrQErvRZfkcg0TXGtd5K+PUeVE2komSpXkdw2nHP5+evPhNsnHIPGZPg008tyvdWG86fm+RrhXpeWNnKxodrbzUyKLZhz/rzldTNlGTuxOh2AfTnTQqXSWJUAsqrWvX6EHsuBcf21A3dllOiol1rUm90902nJueoUU+1vj2U6t8PH9/lRnN3fFNAWLYaplXS7zbx5dQEbmBpzJ5Tz317aXetZfqq8e8r4fxK8WL5MWHStbthrl5h0zr8yC4bXygC2X2Uj9vNxop94tjfUClF/5M0o3+WL9pLxXrWdOPCa2ceeyTcu/TxEbzT9zDylOyp/9dJEKbwhtd5Z52iR7EjvvzKz1Xp4wWLzTwZibebCsDPcNhuDu+HW4MK8u89uPL3TG5ldo08sz6aU5uozt2wcNWFim2Tjl7o+RXa7ewje7eIdOi5p+pfAp80tx4aOt16YXsZnxy69P50Lq2ZnICXWWTdo4eIWPHx/W5Fha8vFP/IT0PGS2OpGd4x0aNvxRv6auNn2OLu+LbIcewh8TktmrTSDqKfXmx7vKv+3zik41HIRlFUAfYVZ68XaNHyNjhX9aX239ljt9x9Az+k22/LqGsj2+HHcPuG5Pbqw3pKIAGHVpXCQB1WRvfDjyG3S8mt1ebBuaOAgAAALtidBTArsI8ZraNRw4CAAIiHQ3lR1uY7H3b6/ogdLVx1Ar9YIAHdtJql1ikTweIHp8OXe8zQc+AM0U6Gog/DV0C4L78Pb0XugzwQj8eugxoCj0DzhVzRwEAABAQ6SgAAAACIh0FAABAQKSjAAAACIh0FAAAAAGRjgIAACAg0lEAAAAERDoKAACAgEhHAQAAEBDpKAAAAAIiHQUAAEBApKMAAAAIiHQUAAAAAZGOAgAAICDSUQAAAAREOgoAAICASEcBAAAQEOkoAAAAAiIdBQAAQECkowAAAAiIdBQAAAABkY4CAAAgINJRAAAABEQ6CgAAgIBIRwEAABAQ6SgAAAACIh0FAABAQKSjAAAACIh0FAAAAAGRjgIAACAg0lEAAAAERDoKAACAgEhHAQAAEBDpKAAAAAIiHQUAAEBApKMAAAAIiHQUAAAAAT0KXYCHsD/TBwFO+5b/29A1BwAAODVHmY7qU/rTAGf9UuhqAwAAnJ7jTEe/5+P2T2rd0NUGAAA4PcwdBQAAQEBnk45afL/fWmRR6DIDAACcvuO8Wb/EIs1uoxcae772b7oabDxIR73yWMl0IoAX1rWBF6FrBwAAcNpOIB31Qj1zPfPcInWt45e3/8Iy5ZsSS4sUSZJ1JBU20tAHkgbqTpNUAAAANOUE0lHJEhWeS17YlV7ZYGWEtOMXGw+QaSBZrNh7kknXGkheWGHJ+tFWAAAA1OM05o6mmq20z6aJaZUl2pZSTpPOSF2LJB8qslSSNFYWumoAAACnraF01DJ7pdReWtJKLcqE01JlWh0HTRfpqPXtxl7ayG5sZP3yZ7EKSfLczQvJMhXl/NFc7ZQfAADgbDVys94iXSuSFOuF3m6hFqkm1pcUr70pH6mcN2qZht6zjg+s61fz32e3ljl1KjNGWV0PAADQqEfWbSDlejI/Zmx/pO/Xfvx3qt9YIvl0XfzIOr66gj6Z3cr3oWSJJhZrUvl97JXvrF8uZJqqLoB6ZzaeGtgTfVvfCV2IPX1WXwldhEBlauMsb+hH9H4Ldbmfn9b/Dl2EPZ3CO+8z+rvQRXiwQ4oah1SWmWNun+Ffzx9r4Rz15hDv7H+IvbxVc0Y0fKRxA+noa/pC+dX39F8beBmWx0AXM0dnK+QjJT62tFxPvzxztOOXli7SzOWZpZYp96HFUpmiVl+bVwrwLKg13tRH+ih0Ifb0vr4eugiBytTGWV7Ta/qwhbrcz/88wDLdzym8876qb4YuwoMdUtQ4pLLMHHP7DP96vtvCOerNIS72P8RevltzRjR51MzKcbvUtaRCl008ztNeLX27SCgT9ST71/opDe1GvdWNmizSdMP76uKn+W17SzXxXFLiw/JH1dHRVyEeTXqiDvGVbKdMh1hz4Bgc0nvnkMpyCoK/nq08BLzWHOJWHtS+2h/W3tBSJh/osS709jyta4gl1lequFwJnyuyTN/2gWKNfTy9ha+h0vk/6JTNvrJEabYjqcV6oRtzcy0WObHNEwAAQKMa23fUizY+73iuvDICeqFEExUWTVfTT3cN9bzyuWfgheRjK2eLWrZIOH2ix7cOn6nhdBoAAODcncQ2+DPTFLhcnBXbYoOnoaWzR3+WfzlbvJT4pucuxWyCDwAA0KyTSkenKls4zX4ytK6teUyobVzEZX0eEQoAwMl7bOn+B9ni9VqP9rEWSrzJ4/0PsewE09F1/Grts5kiDe76FxZNb+wDAIDTZZG+peaTu3p3D/hfLZR4k2/VfUDzoPV5YKFHHmCLgzBnBQAAOG2n8cx6AAAAHCnSUQAAAAR0nHNHXw8yhbfeacgAAACQ9M8Ewql0GspJfAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOS0wNS0yOVQxMzo1NTowOSswMDowMMH8ocEAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTktMDUtMjlUMTM6NTU6MDkrMDA6MDCwoRl9AAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc4 = qc3.resolve_gates(\"CNOT\")\n",
+    "qc4.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.354-0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0\\\\(0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354+0.354j)\\\\0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j)\\\\(-0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\(0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0\\\\0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354+0.354j)\\\\0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j)\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[ 0.35355339-0.35355339j  0.        +0.j         -0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "  -0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.35355339+0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339-0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.        +0.j         -0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j         -0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j]\n",
+       " [ 0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339+0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339-0.35355339j]\n",
+       " [-0.35355339-0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j         -0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.35355339-0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339+0.35355339j  0.        +0.j        ]\n",
+       " [ 0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "  -0.35355339-0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j         -0.35355339+0.35355339j]\n",
+       " [ 0.        +0.j          0.35355339-0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j]]"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U4 = gate_sequence_product(qc4.propagators())\n",
+    "U4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABOUAAACTCAQAAABrYmXDAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NNwnXlEh9AAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAFiZJREFUeNrt3c2r5Oh1x/HfMQ3ZzMRRB8JAEzqWe7BXMYMaTFaThe4if4AmgeCVoRpnn1RB1oG6zh/gdO2MCSat3WyyuLVIwOAYWgyOZ5EwM/LMYsD2ooXj2QQHnyykelfVrbpXVXrp76dobnW9SDr16KhOSc8jmQsAAOAU9rcK9esLz/TLyv0f2468ex60vQAAAKB3QuX64MLzfEdh22F3EaUcAAA41a/1gc8vO0uT/rDtsLvoS20vAAAAAO6KUg4AAFyAhac9a4EFbS9zHzR8gNV+oLf1mxbjeaS/8X9rcf4AALx2LNC4ulto7lnta8aaHZzISJNqWlF56NYLG9vMi7Mt9c/18cU/qjf1kX+r2Uk23Vfuc33/0sfO19mU3n8AAFyWF5qY66lnFmhsI3+2/QpLlB0qyixQIEk2klTYjVKfSZppXBZ4Z/GxX136k7JYcdPTpPABAAD3ZJEKzyQv7FqvbLazZ250S9mUaCZZqNAnkknPNZO8sMKi+r18WKCvHAAAuK9Yi2NySVnUrbNIt5VjZcEWaGyB5KkCK/dezZW0HVrXsVcOAADcV1WsWaxEu/vf4kUpZ1PFCpQrUKHMq4OnFqqQJM9kkmSJiqq/XGbTtkPrOko5AABwX7Fym0oKaw+kBmWpZolSn9jIZzb267Xnk60hEaO1HnKMYr3FAxs3+iG9qw9bjedremyNdyi8k2/op20vQoO+pk/1v20vxBl8WX+gz9peiMb8nv5E/932QtzTsFpkaNuBP9V/tr0I9zaEFulKDBvf9xZJ5R42u7GR745UjcrDr55KFim3UPnG86Gv/d+m1aCH0mqwxFt6t9F9dI9a+NyajkE+eaB5o6XcY31x4Q9l0y9auJBIvc/0UduL0KAP9Yu2F+Es3tAbg4rsrd5HM7QWGdZ24Gf6ZduLcG9DaJGuxLD5fb/qKResqgqLlUleSBs95Ub+zOK1Am2rJ50lyjy1UKrKu1WV8oU+VZNnyfjzFj63pmOQ9KDZcSEWt1zKtXAhkT26sRQA2sR2oGuG0CIdiWHr+35VjEWaSBZ5ZokixdLmyUQsqK6jGq9Fkuh6bbq5Z5IiT6uHVkXfF/qsye94G99/GidrOAaJEawAAOAeLLKpYoVV96ZMgSUqJE91rbwa2JAuz6Y2qkq4aH0aizPOWagXemlurunyEU5FcguGPQAAgDvzTNnanrcrRco9lyxS6LPyrHCeLfeAzbyQfG7LvnGWrIo1z/Vwa/KJUuEg9soBAICGeOFzzyULlSiym+Xet7Tca7fY/7Y2zGF1KLVOyAmCb8NeOQAA0DDPN/vIeWpjq7l0lx0cemnTM162azDYKwcAAM7Or6sBD5sCzfa9w4LycCwOY68cAAC4gLpDpZ4feH0hCrkjsFcOAACgtyjlAAAAeosDrAAA4FSP9e2LXyjzcdtBdxOlHAAAONUP9aWLX9/pDf2u7bC7iFIOAACcyN9vewmwQF85AACA3qKUAwAA6C1KOQAAgN6ilAMAAOgtSjkAAIDeopQDAADoLUo5AACA3qKUAwAA6C1KOQAAgN6ilAMAAOgtSjkAAIDeopQDAADoLUo5AACA3nrQ9gIAAAB0iQVKFKrQTLGnNlIoST5Z3ZNsurwXKfbr5XtjxcsJpZ6df2kp5QAAACRZpOf+VNJzPfOiKtdSn9lUsT+VfGZjjf2hJOlaU00kSYkSLUs5n1umV3rohWRjm+o9L8671BxgBQAAkOSZP5UsUlCVX4sCLVVkgSQpU2DlnrlC2bJICy1am0pR/pP8WoFG515qSjkAAIB1VeHmheaS5JlyJZKkUFl5zxKlkmSRUqXVs7sKBedeWEo5AADw2rPAxvbcIskzZfrEXtjYQp9XT6dVD7hgVbZV++RizzSvL+UsUqTZuZecUg4AACDxawXlPjS/0rWksV4uD5ymSiywULlSReUh1kogKVVo8frEbGpTGyvWVz0/94Iz7AEAACC1QNFiL1w5ItWea6z3JMkzy5Wo8FSyTInl5aFXS5RbLGmuRPO1qc19ftrs7469cgAA4LXnhRa93+LlHraJVvvf0uVJRlIly8Orkc987nPN9vaWOztKOQAAAGmkmZUF2aJoC7Q6PLoa2pBqNV61GsPqqWQtFXMcYAUAAJCKZYkW2FiZpKQ6c5wkzyzzVJI8t0xzyWKNFFrmc8mmKjS2yCfVKYIT06UOsVLKAQAAyK8s9FxSpswLiyV/tvGC95b3rryQfL7qHeeTRdHnc81XBeAlUMoBAABIKkebVqf3ndc/u3pFV9BXDgAAoLco5QAAAHqLUg4AAKC3KOUAAAB6i1IOAACgtyjlAAAAeotSDgAAoLco5QAAAHqLUg4AAKC3KOUAAAB6i1IOAACgtyjlAAAAeutB2wuAc7Of6+O2l0GS9KY+8m+1vRDAcexf9Ud61fZSSJIe6lf+Fw1G1sYW4Yl/5eLz7DT7jv6uhXb4uv9x25HjHCjlhu9jv2p7ESTJYsVtLwNwtJ9q7vO2F0I6Q+a0sEWwm0vPsfM+0r/45NIzpR2GigOsAAAAvUUpBwAA0FudKeUsPOVZCyxoe4mH63BbHPse2givm6Fmzmlb5y5GMAy0A/Y5c1+5jV4eqWfVIzt9UGys2cEJjbTsVWCh517Y2GZenHnp2+mY+kTf9e+dKaJA4+puoblnta+5rS3qVS1kgaKydS/TRuiilobanLFr/XAz5/bIjt06k/t318j6RTu8xs5cyvncMr3SQy8kG9tU7/m8LObWX2WJskOrmwVa/23xQk8lzTTWuTuNttMxdaqPzjVtLzQx11PPLNDYRv5sZ+63tMWeZa5ayEaSCrtR6jNdpo3QRa0MtTlnl+7hZs5tkR27dSb37+P+6xft8Ho7+wFWL8p/kl8r0Kj2RaNbRoolq18jNlpOt7Doch/UUFikwjPJC11rVPMJ3tYW9RLNJAsV+sxTzTSVaCMMyXAz55bIjto6k/v3de/1i3Z4rV22r1yhmiP3Fim75X3RYoezhcq1+GUyV3LRpR+G1R7RpNx0rDuiLeqVLRRobIHkqQIrD6zTRhiK4WbOgciO3jqT+/d13/WLdnitXbCUs0hRtXctsMRie1F1yYwXK6lN7aV9Yjf20m5sunxfqNVu5Wj1y8Qz8WvjdNUmwWIl2j0IFh/eYBxuIc/cvJAsUVH11aCNMBTDzZxDka3FVRdDRyIYgqPXL9oBuy5yimCbSiokfXVxrN9TycaKNJcUlCuhJUp9YiOf2div196+PLxqyWYfOzE653SxcptKCmt7MwU61Bvj1haqrA1SoY0wEMPNnEORLePaE0M3IhiCI9cv2gF1Hthz3WEA/V5P9Jl2j+hvj1jd3OiVBV1Z3kXKLVS+8XzouVQeXN3q9rm78fymrqy5i+081K8a/GyO9Y1GY5CerO5aJJUDOezGRr47HipatZ6NttaM+W0tVL1vWnW4La3a6G39Zed6bbyp39fnbS9EYx7okT5reyEkSe+0M9dGBz5sbMsGlTlP1v9zS2TLuPbEcFwE0pPOXGfgSUcuZLjx7XL8+nXPdvh6R9rhoX6r37S9EJK2suFCGv8u9KsHuyNl7uNOoy/XD0yM/JnF66veWh+BWKElkiKbVsXh7q+NnzR5sZ2WLjXV8AWDNlJ31R9jbVSwxcqqwSlrbeH1A98PtZCqcVaphVK1aVm1USvjgdGGlr4uPmhy3OzWtmwncyxS4blkQd8yZ6t1arYJ9VuE3RiOjqAzlw/sjq1vl7pWWF/DmmqH/6IdNrWyrTrDd2FnThEsSRZUv2bXV/FEaXnHZz7xiU8U+KQqdThfzqlWKR8pK38LWqJY4+VZjQ463EKSxco9lRQtfyPSRhiC7cz5jqTnko2O61Te4czZ2Sbs2yLUxNCNCIZgtxVi7VnDaAfsOnMpZ7FNJSUWrx5RpMhiGymsHk+Xq+So+mWysetx/aCqhTaVbGqxZOEdx4y9piyyqWKFVVtkCixRIXmqa+XVb4T0lv2QB1vIQr3QS3NzrTrj0kboudrM+bHKdXtx4KuXmVO/Tdi7RaiJoe0IhmDPljnbWMNoBxzmjd40VXyHd72o/gbV33D5TKJk77vGipqZ/945xJo2+/mc7zM8ML2b2kcDxeXnrEiJa/FZLtpiz7ROaqHNNmrn0+TWxq1+nevXXPfl4SJzyudX8+xP5uz7nJaR7dkibMdwfARtrRFdvu1r1bUt88YaRjucqR1a+ETO8V3YjQOsafl7ZDm+ddWBM/J077tC59fGnXnhc88lC5UospvlL7zU4kPvqv4e10K0EQZnkTnKFdloret57zOnjGz/FmEnhs5FMATL9Wt7DaMdcMBFTkZyG09tbDUXJTl0KWCbcjmSJni++Tnua4t6hy/WTBthyPzapqtxq0PJnGO3CN2NYDjW1zDa4UyerM7zeDGPm59kJ0o5ya9rz2Yd7Lt8sAXiIsFnsqct6gX7L/BMG2G4LFBoo6qDeWWomXPq1rl7EfTR7hpGO5zFd893zfO93mh+KEpHSjmpbiew53tfXTAq53yO3yG/v4VoIwyZF3V7O4aaOadtnbsYQf/UrWG0Q/P8e20vQTO60VcOAAAAd0ApBwAA0FudOcCKs2n2ckZ3185l0IC7eaxvWxtXe6lbkma1sUVo51JuXfaW3h1Gh3t0AaXc8L3dlY6vxmWd0R8/1Jf0RdsLIUl6Q79rdHotbBHI/R0/0pstdLjvxjWa0ThKucHrSiHXpSUBbuPvt70EZ4ushTwk97f5p2qjw32DV/dGl9BXDgAAoLco5QAAAHqLUg4AAKC3KOUAAAB6i1IOAACgtyjlAAAAeotSDgAAoLco5QAAAHqLUg4AAKC3KOUAAAB6i1IOAACgtyjlAAAAeutB2wvQVxYoUahCM8We2kihJPlkdU+y6fJepNivl++NFS8nlHrWdizApZyWN5uZQ94AQC1v9Kap4man2Ob8FWu681ikly6XXiio5jit/r6sXjHWq+peoOfLV32yMZVAXj0z1k15ryufITdu973ppuaxSC9PzZvtzDmUN/Vz5caNG7fh3zjAeiLP/KlkkQIvJEmLfW2pIgskSZkCK/cwFMqqV0mhRWtTKcp/kl8r0KjtqIBz88yf3iFvNjKHvAGAXZRyd1V9AXmhuSR5plyJJClUVt6zRKkkWaRUafXsrkJB28EAF3JC3tySOeQNAEiilDuJBTa25xZJninTJ/bCxhb6vHo6rXryBKsvn2rfQuyZ5vVfSBYp0qztyIBzWmTOiXlzIHPIGwBYoJQ7ReLXCsp9AX6la0ljvVwe/kmVWGChcqWKykNFlUBSqtDi9YnZ1KY2Vqyvet52YMBZLTPnpLypzRzyBgA2MYL1FKkFihZ7E8pxdfZcY70nSZ5ZrkSFp5JlSiwvDyFZotxiSXMlmq9Nbe7z02YP9NRa5hybN3szh7wBgA3slTuBF1r0fouX+wkmWu1HSJcnS0iVLA8TRT7zuc8129tbDhi0ReaclDdkDgAchVLuNCPNrPxaWXz5BFod5ll10E61Gq9afTF5KhlfSXg9LTLn+LwhcwDgKBxgPU2x/KoJbKxMUqLJ4knPLPNUkjy3THPJYo0UWuZzyaYqNLbIJ9WpThMTh4rwmlhkzlF5U585mpM3ALDLvNnJTdvtydLs/C1W7JOtx0LPJQskLyzW1pdK+awkWbB2ZqwWYwAuz278auex0PNz5k39XAFg+Ngrd6LyK6c6Tem8/tnVKwCUPCdvAOAc6CsHAADQW5RyAAAAvUUpBwAA0FuUcgAAAL1FKQcAANBblHIAAAC9RSkHAADQW5RyAAAAvUUpBwAA0FuUcgAAAL1FKQcAANBblHIAAAC9RSkHAADQWw/aXgDgbuzn+rjtZag80Xf9e43F9df6e31+8Rje8D+7+DyBO7Ef6G395uKzfeJfaTtyoB6lHPrqY79qexFKNtVHDU7ul3rfJxeP4ebScwTu7HN93+eXnik5gu7iACsAAEBvUcoBAAD0FqUcXiMW3v8dFljQdhynxdWPGIDzOpQl5Aj6jb5yGAQLNK7uFpp7VvuasWYnT3ikSTX9qOyd44WNbeZFj+JqOQbgnI7JkVuzhBxBr1HKYRC80MRcTz2zQGMb+bPtV1ii7NQNswUKJMlGkgq7UeozSTONdaGBCfePq/0YgHO6PUduyxJyBH1HKYeBsEiFZ5IXdq1XNtv5dT66w4jXRDPJQoU+kUx6rpnkhRUW7fv137m4OhADcE635shtWUKOoOfoK4ehiLU4PUFSbtjXWaS7bJLLDXmgsQWSpwosliTNlfQmri7EAJzTwRw5IkvIEfQce+UwFNXm2mIl2v0FHh/emNtUsQLlClQoK8/rZqEKSfJMJkmWqKj60WQ27V5cHY4BOKfDObKWJeQIholSDkMRK7eppLD2UEqgQ/3JEqU+sZHPbOzXy4eTrY7So7WeM5cb3XZkXJ2OATinwzmyzBJyBEP1wJ7r5BM0HPBEn+niZ+Fe801d2avGpvZQv2ohhm80GkMzHutz/V/bC7HlnfX/WCRVv7FvbOS7Y9WixXppo601fu5zTyWLlFuofO2Z0Nf+Z9OqM3RpvTBstsU21rrj47pnDO80ei77d+4/ibvMtYPn43/SmcvLNeFRC5eUq7PxPXNrjiyz5J458qQz61f/16qH+m0Ll15r1iP9T1di8KsHdaN97q7hSxid7ieaN3dBF4sVtxDDT5uMYbi2Nqur3jKL0WiRCs8lC7yQVochfd8pCUb+zOLVpnuzf40lyjy1UKo2++u/1httsa21bieu6jWZtBnXPWP4oMnLoLX0lddoDOiure+ZmhwpTypicTVudT1L7p4jnblUILCNYQ8YhtUGOVIm2XckPZdsdFzHZQuqfXWrMipRunw2Vu6ppGj5+/1S55vajiuSLFGs8fJcWt2PATinnRyxQIkyeyltZwk5gmGilEPvWWRTxQqrUWeZAkv0Y4XKtDoAmd6yh3VUvS5aPbQ4D5WFeqGX5uaaLh+5wCkKauMqJE91rbw8pLQRVwdjAM5pb47MFGru850sIUcwSAx7QO95pmyto/KVIuWe219prmU/GM9sfHAiMy8kn1v1a9yStUOyuR5uvXrtl/yl45IsUuiz8oxXG3F1MAbgnPbkfmBBOWp1J0vIEQwSe+UwMF743HNJuSIbrXVvTi0+9K7q7+L1kR/aiIeXP3HoIi4LlSiym+V+hWVc3Y8BOKdl7o80VqDQ4mX+V1lCjmCYmt4r91jftjaGCiy8q/9ocGpv6d0Wziv0rj68+DwHya9tuhrn5qmN7chLdx2+kLZN27ycj+ebc98XV6sxPGrlfFyPWpgnOmjtRCOLR2qzpMt5Dpyi6VLunxToixbj+VD/3uDUfiTpFy3E8KOLz3NwLFBoo6oTc8Wvj77mQ7D/0tsWqGMX2d4TV5sx/IN+2cIH8bMW5omeqM2SXuU5sF/DpZw3WUi1zj/Vp20vA+7Gi7pf1MceLlk/z1TNlDu3ga+Lq80Y/J/b/kSAbbtZ0rc8B/ahrxwAAEBvUcoBAAD0FicjQV+92eoAm3WP9UaDU2tnsA1DBtAf7Qyve9J22MA+/w9MZ11AmIM5GgAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOS0wNS0yOVQxMzo1NTowOSswMDowMMH8ocEAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTktMDUtMjlUMTM6NTU6MDkrMDA6MDCwoRl9AAAAFHRFWHRwZGY6VmVyc2lvbgBQREYtMS41IAVcCzkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc5 = qc3.resolve_gates(\"ISWAP\")\n",
+    "qc5.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.354-0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0\\\\(0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354+0.354j)\\\\0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j)\\\\(-0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\(0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0\\\\0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354+0.354j)\\\\0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j)\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[ 0.35355339-0.35355339j  0.        +0.j         -0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "  -0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.35355339+0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339-0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.        +0.j         -0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j         -0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j]\n",
+       " [ 0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339+0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339-0.35355339j]\n",
+       " [-0.35355339-0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j         -0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.35355339-0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339+0.35355339j  0.        +0.j        ]\n",
+       " [ 0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "  -0.35355339-0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j         -0.35355339+0.35355339j]\n",
+       " [ 0.        +0.j          0.35355339-0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j]]"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U5 = gate_sequence_product(qc5.propagators())\n",
+    "U5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Or the transformation can be in terms of any 2 single qubit rotation gates along with the 2-qubit gate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAACCIAAACTCAQAAAD7G+LcAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NNwpOnRnHAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAG0dJREFUeNrt3U+IJOmZ3/Hfs/TeZrREs4iFPgwK1YBOXtrRMOxpdIg66LomRgYfF7LRwQdfnAU+C7K0xwWPO1kfjBFGEywYXXTovBgEkmCCYfAejLs3pTk0eAa5Q2jmuPjxIaMys/JvZFZkvJGR308xTHVlVWT86s1638gnIt7XXAAAAABw6ewf9ERfh96Lyjv+Vw0m+61et57gsb7yHzSY4TP9vvUM7+qN/6vWn7XzHoXeAQAAAADogFf62Cehd2LGXja6udd+3XqCVGmjG/x9DzL0xJ+E3gEAAAAAAHAeKCIAAAAAAIBaKCIAAAAAwFEsbuJnLLIodJLDkpHhkjU8J4L9Qt/W24B5rvTv/L8HfH4AAAAAPWCRhtWnpSZebPyeocZHbHqgm+oZktkcDF7a0MZenlEyMhyz1yEmuJSu/DvNbrDpiRU/1yTkZCQ20jfhnh0AAABAP3ipG3M988IiDW3gz1e/wzIVh7/htEiRJNlAUmkvlftY0ljD2Vvac0hGhiMFmOCy8Uk6xeoMAAAAALCBJSq9kLy0W7218dr57sFRbwkzjSWLFfuNZNILjSUvrbRk8xn1DiYjw0VjTgQAAAAAWJfq7hrrbPaGdZklOu6t5uwtaqShRZLnimy2jOBE2dkkI8NF40oEAAAAAFhXvRG1VJnWz2qn+96m2kipIk0VqVThs/vvY5WS5IVMkixTWd2PX9ioa8k2JSADKCIAAAAAwLpUUxtJijdeGB9p53wIlin3Gxv42IZ+O/9ytjLZ32DpDvz2VgaolWxLAjJcvEf2QkcsS7LVlb5QwIkV9YGuLeTqEMu/iRAzb57Ku/qW3oTeiZN4oi/1z6F3ojF9a6cnvUqz0Ld26kNvR4aueVd/GnStp9N5T28YdTqFDN3QnQxX+vXiH5ZI1dUDL23g6/P8J4v3PTZYeU818YnnkiWaWqzp0iOxL/3LRtV0fjPLRYmnjU6H93T5H3WTbUlQN8P7+qElDWb4XoAM7zSc4enDN3HMszY7taJfP1qfx/IhbKRX7f5GVvwm7OoQAAAAAM7Tykpvi3vu7+bxj5T4xNJq1v+lmxl821KCA39u6eJN6f079S1T4bnFUvWGdvkM+GdNzuO/8iZyPVmi0qeSRavJVhMckOGVfuYNrnOwN8PW1nlAhm9OmqEtjb6WJCZWBAAAAIB1izeaiQrJvq9MhX0qaVhvAxZV1yek8y9lyuePppp6LimZnxM/eLnIhpL9SNILyQarUwpuSNDVDFtbp8MZzhZFBAAAAABYYomNlCqu5usvFFmmP/hYsSY+qc5N5/felm4yqM6WL10Q79UbVIv1iT41N9do/pUWFhbcmOxXmj333Q0ai2QbEnQ0w/bW6WSG88bEigAAAACwxAsVSxPtXSvRVKVFszn/LfFC8sL2XZEw9lLyiVVnuC1bvD31qR6vfPfS2fF2k/nU/rUmms8TsJRsJUF3M+xonU5mOG8UEQAAAABgKy81kWyoSFJsi6Udc0t3zcd2d7Z7fpl8svP++thbPwM+SyZpquTe1INVsrUEnc2wvXXOIcO5oYgAAAAAAHvcWyBw9pXchlZ4zTvobefCgTZSgxP4HZPORovVJrYl626G+q3T3QzngzkRAAAAAOAIfruytOMukbat4SCLZhfdh2GRYhtU0wvuTtbZDJv0IUM3cSUCAAAAAByl/qXvS5fTrz9WhlwRwMtNZ983Jetuhi371IMMXcSVCAAAAAAAoBaKCAAAAAAAoBZuZwAAAAAA6QNd29vQO1G5anRrT2zUeoL3Gt7e9+xl6xke64+tP+cZoIgAAAAAANJfd2dSvd1rCBzs7/Sq9Qjv6P81ur1/EaJ1Gm6HnqCIAAAAAADqTgmh6X3xj0PnaSBDkNbp0muiO5gTAQAAAAAA1EIRAQAAAAAA1EIRAQAAAAAA1EIRAQAAAAAA1EIRAQAAAAAA1EIRAQAAAAAA1EIRAQAAAAAA1EIRAQAAAAAA1EIRAQAAAAAA1EIRAQAAAAAA1EIRAQAAAAAA1EIRAQAAAAAA1PIo9A4AAAAAAHC5LFKmWKXGSj23gWJJ8pvFZ5KN7j6TLFHqt9XPpkrnG8q9OP3eUkQAAAAAACAAS/TCn+mFnntZFQpyH9tIqT+TfGxDDf2xJOlWI91UP5YpU1VE8IkVeqvHXko2tJE+8vK0+8ztDAAAAAAABOCFP7NEUfXGvyoMKFdikSSpUGSzqxFKFUvlgdiS+TbK2X+S3yrS4NT7TBEBAAAAAIBwqpKBl5pIkheaKpMkxSpmn1mmfPbNlihXXj2+qlR06p2liAAAAAAAQMsssqG9sMQLFfon+8SGFvukejCvZjqIFuWC+XUIqReabCoiWKJE41PvN0UEAAAAAADalvmtIkWSX+tW0lCfzm9SyJVZZLGmypXMbmiYiyTlim0xoaJsZCMbKtV3fXrq3WZiRQAAAAAA2pZbpGR27cFsrQV7oaE+kiQvbKpMpeeSFcpsquoaBcs0tVTSRNnd1yRNfHLo0x+LKxEAAAAAAGiZl8qUS5bOrym40eKag3y+dGOubOlmhsTHPvGJxltmRTg5iggAAAAAALRvoLFl0rxcEGlxM8Ji6sRcydLPVMUEzyULUkbgdgYAAAAAANpXVuWByIYqJGW6uXvICys8lySfWjG7ccFSDRRb4RPJRio1tEQTpZIyU1s3NFBEAAAAAACgdX5tsU8tUuGlpZI/v/fwR/PPrmc3M/hkMQuC38wLDpNF6aENFBEAAAAAAAjAp3ezHaxfR7BYZ2E+H0InMCcCAAAAAACohSICAAAAAACohSICAAAAAACohSICAAAAAACohSICAAAAAACohSICAAAAAACohSICAAAAAACohSICAAAAAACohSICAAAAAACohSICAAAAAACohSICAAAAAACohSICAAAAAACohSICAAAAAACo5VHoHcCp2W/1OvQ+VJ7ox/7TxnL9SP++M8mu/DvNbcz+QU/0desZ/tyftv6cAHrIfq/PQu9D5an/eYO5fqR/qzehI1Ua7bHtF/q23raeodmR81f6pvUE0jv+VwGetcP68FoCUAdFhP577dehd2HGRvqywc290s/8JnSmKtnLRjf3Sh/75MwzALhcn3Vm1Gm6b/55T0edzzU5+1HnmxCvOkbONX14LQGogdsZAAAAAABALRQRAAAAAABALZ0pIlh8yKMWWRR6j/tsd2vU+4kuttHhufqR7DwyALhcfR11+pusD6NOHzL0Ae0AnKMTz4lgqdL5P3Ivqq+s3S9lQ413bmig+X2IFvvUSxva2MsT732Yqfuu9BP/+ESJIg2rT0tNvNjyXftaY5OqhSxSMmvddtrokGRH5epHssAZANQVZFLCx/rKf3CyRKfqnc+gb+5vsq6POn3I0Ae0A9BfJy4i+MQKvdVjLyUb2kgf+WRWRlj+LstU7OoMLNJyzfETPZM01lCnnuAoyNR9NtKrU23bS92Y65kXFmloA3++4fn3tMbGfa5ayAaSSnup3Mdqp41qJzsmVz+Shc8AoLYAkxLeK/c37jS9c/h+jfGUDNiHdgD66+S3M3g5+0/yW0UabPymwZ6ZXLNFldIG8+2WlrT3i+oLS1R6IXmpWw02/gb3tcYmmcaSxYp97LnGGkltt9HeZMfk6keyDmQAcLlO0jt3oF9jPCUD9qEdgL5qd06EUhvuYrJExZ6fS+4ugbJYU91VLCfKWt37flhcBZLNOvb7arTGJrMWijS0SPJckc3Oa7XZRjuTHZmrH8m6kAHA5TpF79yFfo3xlAzYh3YAeurEtzMss0SJZhcyRZap1EDPvZSU3nUhNlKqSFNFKlXc3UhgsRYXOiWeW3V/lRc2Cv3rO0NVh22pMm26aDbd3aFvaqO7FvJCJkmWqazuW2uzjXYnS/cNVH1I1uEMAC7Xg3rnDvdrjKdkwD60A9BTrRQRbCSplPTdu/uePJdsqEQTSdGsi7BMud/YwMc29NulH5/fzGDZ/bkUxOysh0s1tZGkeMt9t5F23Zu2uY2ylUlxlqbBbLGNdifbmasfyTqdAcDlekDv3Ol+7eLHUzJgL9oB6KlH9kJHLHu31ZW+0PrdTaurMdwfVmelhFlhIdHUYk3vPR77VJrdyrAy+cr68PyBru1tY2ke66sGfzd1/WWjGaSrxaeWSFV196UNfNN8uMld+9lg5ZUx8cmWNqpaqPq5UTXtzcxyGzWb7F7r7E2WLF6XJ0j21F42lku60q+PSfbADN9rNEMznuhN6F04iXf1rV4luwqwik1/M1w9fBMHe18/bPT+4nsZ6vdhJ+ibrxrt1x7rfx+Q67TJmu2x7x27tTbqNDtyPl3+x5lmOF53RpU+vJaa+k10ZVRpwhP9UV+H3oneZHj68E0c86zN/pX49aNN8wkf76iVBZYv9xv4c0uXO4al+6VSxZZJSmxUlSXWq5C/WV8+8gFpTjpj9VafN5lBuveSWdybNl/xYrZojqXV/Ljz1vBtS+6stNH9O9osU+G5xVLV8S+3UaPJVlpnU7JEpU8li7xc3scTJGt0PnUb6Ztdyba12AMz/K/254QHsCrIoXDDKxGtZFjvw5b75tOOOq8b7Zv3jzrtjaeN9tgrx24HjKcPytDsyLnvVXeakTPAaird1ofXEnBagUpejf+VtDux4h4WVbX65WE6Uz77xMd+4zd+o8hvqreirBF7qEWHnKiQLLFImQr7VJqv5bvThjaat5BkqaaeS0rmteO22mg9WSrphWSDepPvnE2y729vsc5mAHC5VvuwH6mfffNFjqdnk4GRM4w+vJYAbHTiIoKlNpKUWbr4ihIlltpAcfX1fN5hDKqK5b3LKpdvYbDYRpKNLJUsPnK+/QtliY2UKq7aoqimt5SPFWvik+o8VL7n6osNbXTXQhbrE31qbq7R/CsttNGWZIVmzz67WG5frvNJ9ocdLdbBDAAu18Y+7Ff3+uY+jTqXOJ6eSwZGztb14bUEYAdv9EMjpUf81CfV/6Pq//H8kUzZ1p8aKmnm+bc+Q6pRs7+f0/0Od2zv5cavRkoV++wCs6Ey191v8641tmxtpY12tdBqG7XTOnfJ7p7vLv/uXA9M9rLePj/sFTBLtqvFupOBDz74OO4jxF9i02Pdtgzzcede33zSUafZvnnPqNPqeNriqLP4jvXxtEMZdr7qGDnb+ujDa4kPPk77Eeb12vyzduN2hnxWp5yv3bCYRiXxfOtPxU4V8mhe+sSnkgYaKlJs6Xwqm9zSXT9X/f/uu3e1UJA2mieTpkpsUC/XGSXb0WLdzwDgcs175/t9c39GnQscT88mAyNnYH14LQFY1soSj/t4bkMrVlZekGQ7lm+xkRqcBupy3VtMc/aVLa2xie1cYCd8G/mtjRYz/9bP1eVk9VusuxkAXLblvrk/ow7jaXczMHJ2yXm/loAHe2KjEM/a9AY7UUSQ/Pb+HKyVSFtmNLZI47pvB3GoLa2xydYWCt9GFim2QTURz6G5Op1s3aF/P13MAOAyrPfNfRl1NulHstrjaYczrOtDhvPTz9cScJAf68sAz/o/m95gR4oI0qbLkpZXh115pGRW1lOqe5HY9hYK30Zertep61/81uVkG/fpoL+fbmYAcAk29c39GHW27FUPktUdT7ucYeM+9SDDuenrawmoz38aeg+a0Y05EQAAAAAAQOdRRAAAAAAAALV05nYGnMxTexl6FypX+mIxldaD/YU+DDIxySbNTlbyga7tbesZvtf6MwLop6vO9M1XjW7tqX5oycM304hme+z39De71y86iWZHzqsgxzrNvsL6oA+vJQA1UETov/e7Mv2MRY3uyS/1rl6FzlT5otGt/XWIFts9EzIA1PYf9VnoXaj83yY35n9rf9+d8bTRzf03/Ym+aT1EsyPnv2Tk7IQ+vJYA1EARofe6csjT9J747/Rx6ERzzV1foVAt1p3XCYDz5n8beg/mGu2bu9RPNjye/jxICEbOHurDawlAHcyJAAAAAAAAaqGIAAAAAAAAaqGIAAAAAAAAaqGIAAAAAAAAaqGIAAAAAAAAaqGIAAAAAAAAaqGIAAAAAAAAaqGIAAAAAAAAaqGIAAAAAAAAaqGIAAAAAAAAaqGIAAAAAAAAaqGIAAAAAAAAankUegfOlUXKFKvUWKnnNlAsSX6z+Eyy0fyzRKnfzn82VTrfUO5F6CwAgK5j1AEAAN1AEeFAluiFP5P0Qs+9rA7Zch/bSKk/k3xsQw39sSTpViPdSJIyZZofzvnECr3VYy8lG9pIH3kZOhcAoIsYdQAAQLdwO8OBvPBnkiWKqkOwu4O0XIlFkqRCkc3OC5Uq5gdqsSVLWyln/0l+q0iD0KkAAN3EqAMAALqFIsKxqoM3LzWRJC80VSZJilXMPrNMuSRZolx59ei6UlHoMACAjmPUAQAAnUAR4QAW2dBeWCJ5oUL/ZJ/Y0GKfVA/n1T2n0eLQrTojlHqhyebDOUuUaBw6GQCgexh1AABA91BEOETmt4pmZ3D8WreShvp0fsForswiizVVrmR2aWklkpQrtnR5YzaykQ2V6rs+DR0MANBBjDoAAKBzmFjxELlFSu7OAc3mvbYXGuojSfLCpspUei5Zocyms0tOLdPUUkkTZZosbW3ik8OeHgBwURh1AABA53AlwgG81N39pun8/M6NFmd/8vkiWrmy+WWliY994hONt96fCgDAGkYdAADQPRQRDjPQ2GYHZXcHbpEWl4UuprHKtZgVu5op23PJOKADANTHqAMAADqG2xkOU84P0yIbqpCUVWtyS/LCCs8lyadWaCJZqoFiK3wi2Uilhpb4jaVKJWUmLi0FAOzAqAMAADrGvNnNjcLec9ns81uq1G9Wvhb7VLJI8tJSrRyQzR6VJIvma3UHzQAAOB/20q9XvnL6UWfDWAcAALANVyIcaHa4NjtUW3+rv5jx+tiDOQAAFhh1AABAtzAnAgAAAAAAqIUiAgAAAAAAqIUiAgAAAAAAqIUiAgAAAAAAqIUiAgAAAAAAqIUiAgAAAAAAqIUiAgAAAAAAqIUiAgAAAAAAqIUiAgAAAAAAqIUiAgAAAAAAqIUiAgAAAAAAqIUiAgAAAAAAqIUiAgAAAAAAqOVR6B0A0D/2C31bb0PvhSTpsb7yHzSY7Ld6HTpS5Yn+zj9uMNnv9VnrGa70k+Yy2L/Rf9Cb1jM80Y/9p60/K4Desf+q9/V160975d8JnRzA+aGIAKB5n2vik9A7IUmWKm10g6/9OnSmKtlIrxrd4GftJ2s4w5f6ud8EyPBl288JoJfe6L+0P3Lay9CxAZwjbmcAAAAAAAC1UEQAAAAAAAC1UEQA0AkWN/EzFlkUOskpknUx1+5k59E2+1rnPNoBwKU6rAejDwPQFOZEAHBiFmlYfVpq4sXG7xlqfMSmB7qpniGZ3UnqpQ1t7GXfknUv195kZ9A2NVpnoJtwGQBcrkbGl8D9MID+oogA4MS81I25nnlhkYY28Oer32GZisMPaixSJEk2kFTaS+U+ljTWUC1Nr9dqsk7l2pfsHNpmf+vMUoTLAOByPXx8Cd8PA+gviggATs4SlV5IXtqt3tp47ZzK4KiVATKNJYsV+41k0guNJS+ttGTbmefzTdaxXPuSnUPb7G+dTOOwGQBcrgePLx3ohwH0FXMiADi9VHfLVmWzg6Jllui4w5nZYVCkoUWS54pstpzjRFkvk3UmV41knW+bWq2TeBE4A4DL9dDxpQv9MICe4koEAKdXHexYqkzrZ07S3YdCNlKqSFNFKlV4dRmmxSolyQuZJFmmsrrns7BRH5N1KNdSsk0ZzqJt9mS4SxE4A4DLVXt86XA/DKCnKCIAOL1UUxtJijdefBlp112dmXK/sYGPbei3Sw9kKxNKDZbu8mxv9ul2k3Ul1zzZlgzn0Db7MqymCJMBwOWqOb50uh8G0FOP7IWOWH5sqyt9Mb/4KoQPdG1vG9vaY30VIMNfNpqhGe/qW3oTeidO4om+1D+H3onGdKed7vUElkjVmZGXNvD1uaSTpe8drPRIE88lSzS1WNN7j8S+9G8bVVNGzSzeur+vH1rSaLIl9ZNtyHVMsuWSxHu6bbSnWEq2N9c82ZYM9dqm6d7uXo/94Az3UrSWYeUV1pKm/0qa8K7+VF0bCZvxnt4w6nRKdzIcOXI+sB++spehg0vqUjs040qvQ+9Cg57oj/o69E6QQY+lroyMfv1o04zVx7ORXgVN9BtNvLEihqVKA2T4vMkMQAgrPcHivs7o7vyHJSp9Klnk5fIl/755uaqBP7d0+bDn/t2glqnw3GKpOmhanGV5pZ95g/NQrxxsrSWbLaRlaTVn9nwffdsyXIclWz579IX+c5M9xb1k+1pM927TWMlQu20a7u1WeuxNGba0zr52aC/D2iusHQ3/lQA4xr6Rc0cP9pB++PVR0/8CuHBMrAjg1BYHM4kKyRJLJb2QbFBneieLqrP4y28RM+Xzx1NNPZeUzM+7tLUG9mqy7ytTYZ9K8/W9m00WKteOFtuQoZttk1i0rXV2t0PADAAu1wHjS2f7YQC9RREBwAlZYiOliqs5oQtFlqlUoViF7i7HzPdc8zOozsfcu+D6bnVsi/WJPjU312j+lRYWr9qY7A8+VqyJT6rzuo0mC5hrtcWWk23I0Mm2KaWtrbOjHUJlAHC5Dh5fOtgPA+g3JlYEcEJeqFiazOlaiaY+lWz2ZjT2qeSF7T5vP/ZS8okt7lDPlm4UmOrxyvcvnYFpN5lKi2YzZs9W4W44WbBcqy12L9lKhq62jU8t2to6O9ohVAYAl+vg8aWD/TCAfqOIAKA1Xs7v8ZwqWZoEKrd0+33ld+dTliaJSnbewR1762dZZslsqEhSbIult5pMFiyXpNUWmydby9DRtpE02NY63W8HAJdr//jS/X4YQN80XUR4T39jISYjvPOhft3g1v5CHwZYS/dD/WPrzwm0zm9ttJhb2oZWeM27NG3n4lQ2UrAp4u4tENhwspC57tItWmxbsu62zSGtE7QdrgKMOu+1/owADtRMDxa6HwbQF00XEf6TIn0TMM8/6n80uLVfSvo/ATL8svXnBFplkWIbVFM9SZL89v5c0jtF2rbWgSyaXdbZHc0kC51rvcW2JDurttnaOiHb4ScB1jh6h2nWgHN0aA/WzX4YwDlquIjgTb6FD85/p9+F3gegj7xcPxNS//LK5bWvN2y5c4dHTSQLnWtTi21Kdm5ts7l1QraDfxz6NwLgfBzWg3W1HwZwflidAQAAAAAA1EIRAQAAAAAA1MLqDACa92d6aqH3Yeap/qzR7YWY9m6zD/WFJg/fzNzjAJPivqd3GtwaU+ECOGdhJie/Ch0bwDn6/2f1hsjp7aRwAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE5LTA1LTI5VDEzOjU1OjEwKzAwOjAwmM7kjAAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxOS0wNS0yOVQxMzo1NToxMCswMDowMOmTXDAAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc6 = qc3.resolve_gates([\"ISWAP\", \"RX\", \"RY\"])\n",
+    "qc6.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.354-0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0\\\\(0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354+0.354j)\\\\0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j)\\\\(-0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\(0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0\\\\0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354+0.354j)\\\\0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j)\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[ 0.35355339-0.35355339j  0.        +0.j         -0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "  -0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.35355339+0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339-0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.        +0.j         -0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j         -0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j]\n",
+       " [ 0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339+0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339-0.35355339j]\n",
+       " [-0.35355339-0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j         -0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.35355339-0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339+0.35355339j  0.        +0.j        ]\n",
+       " [ 0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "  -0.35355339-0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j         -0.35355339+0.35355339j]\n",
+       " [ 0.        +0.j          0.35355339-0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j]]"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U6 = gate_sequence_product(qc6.propagators())\n",
+    "U6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAB7EAAACSCAQAAACJI/ZVAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NNws5milRAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAHAFJREFUeNrt3U+IJGl63/Hfs/RFpofZ6F2sxYNcKLpnvRd71UTLljDSjk30wQeDkYmxjBEIFmXhi8EHOwt0lSHLOuzBYKkSJFiWRVYlNkYgbKgE2dhgbCrdrLUGo5lOTWMtlha5Y2anL5KWfXXIqMzIzMh/lW/8ze+nD91VXRURT7zP+0Y8GRFvmBOArrFv6DuVr/RMv+r+c92Ro73snynUJxWv9G1N3S/XHTkAAOiSB3VvAIASvKuvV77OryqoO2y0WqipXlS8zqcK6w4bAAB0CyU20EWfunHVq7RYb+oOG632iV5Unbcmfa7usAEAQLd8pu4NAAAAAACgGyixAUiSLDzk/ywwbgtH7Sw87H/JWwAAUDZuFAc6zwL1s3+mGrtJ4c/0NdyyiJ4usiVFs1t5XWp9G7q07tjQVR6ylrxFx9jv68PSV/KO/oX7Zt2RAs1h39C7+rT01Tx0P+lxm39H3y99i72OFfaP9Is1TNS78JY+cD/nc4GU2EDnuVQX5vTMTSxQ33rufPUnLNFkc9lhwWwiM+tJSu1GIzeUNFR/VsC0nYXqK9bn9ceaaFj9U+wocmzWdj9vcYI+dM/LXoUN9Ed1hwk0ynf09fLPDOzG6+K+37qx4o/0W67GY7PFiv0ukRvFgRNgkVI3kVyqS/UsWvuB3tbDR6KhZKFCN3QjDTWQJJcqLVhS61hPN5q4x/of7rGGGtig7i3CzJFZ2/G8BQAATUWJDZyCWHfFSDIrW/Is0mTrb0duIilQ3wLJjRTY7LO+sZK6AzuWRerrmctuN3Zj90yh9Y9bJjw5Lms7nbcAAKC5KLGBU5CVIxYr0frNQ/FdsWIDu7WXdmO3dnN3NddCpZLkJs5cKlmiNHuudaLSrwZaYq/N2cvSrjte6/2Vm43P1StnSqzSY+maI7K27rwFkMfoB+C08Cw2cApiTW0gKSx8OieYFSOWaOQurOeG1neX8/9NVqaU6uWeZC15dmYLdKVAUqhrPS5h+aGmq1dHXWojxRq1LZYOOiZra81bAHmMfgBOzQPrl3ay8df0v+oOb82ZPtYndW+EN2/rs3pV90Z49GV9q+5NOFJzWuRJ/guLpNkkEnZjPbc+B3M0uyHXjSSLNLVQ09z/hi73lQ2ySaNm8td/z/RV8zxZhM7m41NoX9OfeN9Pz/SX59c9n8z/9eN6v4RrLWXHcn9N6Xlf0bcXXxyZtfvm7Rf0lcY9fc9xqmma0yLvVBJt+0ZyP5oyEhJN02JYOjaV5onXY9GT4xexk9+x4qyCLd7G99nA9IHGpZXYv9vAWSm/oDd6U/dGePNQD/WHdW+ER6/0Qd2bcKTmtMjyVb/FM63BXX+3WLOJpCQtPdPac+cWL0qQ5SdeLdHEjSyUsvIlP3p8rKleeI7joX42+9f39Nsl7Kcf6M/m++b5/F+f0Z/K/+yhi1g+LSWW+2tKzztbGp0LsnYpb7dk7QF5+0YfldDWx+E41TTNaZH3KlhHG0dyP5oyEhJN02I4q6T/v/Z6LCp9PnH5HiueKqxgmzfzfTaQPnC7JowBqtK0E90Ws9dLXy7KjUgXkkUKFSmWVl9eZEE2xOUnmprffGtxdlt15O5uo85fxf5EL/y/1sLOdSXpE/1CGa/MsKmu75Zrr+f/SvTrpaxtFkuq84a9GKwhW2Px0mnMWta6iSVFeVuQtfvn7Ru9alhrABtVMhVjC0dyT5q7ZacaTUNiWDk2leW1z76xchZYDq9jhUmfq2CbN/N+NsB0Z0CnWWQDxQqzm3kmCixR6ka61HT+BsLR/G2AveyQlrtN+m4yMAt1rVtz5rSYCK30j+jcUI/0b/Tzzvuz0ZLkpkptZXZpixSXtLahHul/6nE5S++S4qyVlvJ2a9bWnbcA8sodyQGgaZjuDOg0N9Ekd83vuSJN3dQihW5os5cayU3m10aGLpXc2LKnWC1ZFCNuqkcrC0/8TwpWEEFqr0r8BPlcN5ab8sxCXem8xFher8xfjgLFWTu7/+IubzdnbTPyFkBeySM5ADQKV7GBE+JSN3ZTC5UospvcVb/R7HrhXfk3nygq2nrNIWz/gyZuqnNd28BCyULr6UaXDb6R8STNslZay9tNWXsCeQsAAJqLq9jAyXHT1Wew3cj6Nlm9vrr97dA2WF1KO7mxPVNPV/opXWmiZ1xlbqrVvC3O2lPJWwAA0FRcxQYgyV0WzOUYaLjp5y2Y3Z7bBS51l+65/ot77i66EtNpKMzak8lbAADQTFzFBiBJWr951k23/HQqChXUruiWb/IWAADUiavYAAAAAAB4QYkNAAAAAIAX3CgOdNE7Nqh8nV/Rt+sOG612pq9afPxiDlwnAACAV5TYQBf9K31Q+Tpf6b/WHTZa7Tf0mcrfm/tQP6g7bAAA0C2U2EAHuV+pYaW8TRpHcb9V9xYAAAAcj2exAQAAAADwghIbAAAAAAAvKLEBAAAAAPCCEhsAAAAAAC8osQEAAAAA8IISGwAAAAAALyixAQAAAADwghIbAAAAAAAvKLEBAAAAAPCCEhsAAAAAAC8osQEAADrMwoLvBRbUvV1Al9HvTtmDujcAAAAAh7NA/eyfqcZusuGn+hquf9el1rehS+uOAWiffXoe/e60UWIDAAC0kEt1YU7P3MQC9a3nztd/xhJNNpzQD9XXRd0xAO2zu+fR704dN4oDAAC0kkVK3URyqS7Vs6jgR3puXPy7LlVa+BsAdtjZ8+h3J44SGwAAoJ1i3Z3IJ7NT/mUWabLlt8dK6g4AaKWtPY9+B24UBwAAaKfsVN5iJXpe8P/x3am+DRQr0FSBUk3chSS5iQ3qDgBope09L16U2Os9j353CiixAQAA2inW1AaSQve88P8DpZJkiUbuwnpuaH13ufT/AA63vedl/W5jz6PfdR4lNgAAQAtZJM2uR9uN9VzB/MWKZrezupFkkaYWarr0/8xsDBxsZ8+L7m4j39Dz6Hedx7PYAAAAbbR4HjS4uy5mgcWSxdnbd/NPhPbcWOHKyT1X04DDrfW8Lf2uqOfR7zqPEhsAAKCNFpMqRZpIFlmgRBO7lebv7c1YoFCSFC99m6tpwOFWe957m/rdhp5Hv+s8SmwAAICWscgGihXa7MR9osASpZIbKtTYjWe3sWo0P7HvZdfdcq8LsnDrvMcA1hT2vI839ruCnke/OwU8iw0AANAybqKJLuZfPlekqZtaYMFsNmOL3ERyE7u7qjZ0qeTGln8iNNGo7jiAdinqeUo39ruinke/OwGU2AAAAK3m0uxKWU+BpNAWLw0aWezGkstuTXX5Ejt0XE0DjjDredbf1O8Kex797gRQYgMAAHTC0gu5Zt8ZWd8mruDZTxvkrsUBuDf6HVbxLDYAAEBnuctsuqUlFsxuYAVQBvrdaeMqNgAAQIcV3ZbqUmY1BspEvztlXMUGAAAAAMALSmwAAAAAALygxAYAAAAAwAtKbAAAAAAAvKDEBgAAAADAC0psAAAAAAC8oMQGAAAAAMALSmwAAAAAALygxAYAAAAAwAtKbAAAAAAAvKDEBgAAAADAiwd1b8Cpst/Xh3VvQ+ap+7zHuH5DX9TrymN4on/q/r23GP6x/nkNrfPE/Wjl60SH2B/rReUr/ZL7kbrjbpZaWqGY1xHFfk+vaojBa37Zf9BfrPzo9Ei/5/5hxes8QbW0bbEn+pfuV7zF9ff0tTrORvSv3S/7WxzHJpwmSuy6fOie170JM3bjdXGv9GtuXHkMA73xuLgP9JvuovIY/LYDTs+L6scUsnZNDa1QzPfIXkdcnmP4lsZVH50sVlztGk9UDW1bzAb6wOPi3tRyNjLwXBJzbMJJ4kZxAAAAAAC8oMQGAAAAAMALSuwWsfD437DAgrrjOCyydsSwvW3aEQNODVnbBIeP621pmy7k12ExNDECbHKaZ1TtyNoujB3tVbT3m72Hm5ovJT2LbaES/Yz+ncZuUkUYbWeB+tk/0037zPoaHrzgni6y5Uez55Rcan0burQ5ce2MrAUx7GybmmNoMwsU6339mKkZT9odFUukRH/dehq7aenr2pm3ZG35PLRCMUbFRsZAD9msypGcM6pDoqg6azk21WNpXoiRm2TfWZvDoHjv17GH17e4eJubmy8lXMW2wK51LekvSBrYdZM/+WgKl7oL9TVyFxoqsav1n7BEk0PTwQIFkmQ9JQrsxnqSpOF8eGtAXLsia0MMu9qm/hjay/q6VaSPNFViL63FEwdZaDcaaKr/p1A3Nih7fbvylqytwrGtUKz+tunCqFhSDPSQQtWO5JxRHRhFpVnLsakebqxL9XXpLtyFYruxwI2l1ekYt+z9yvfw+hZL69vc6Hxxnv8o0K36Tk66cXJSXy8V+F5L+//M9k7u60iv53vQKdr183uto6fISaEGTk5K5mvo55d/nyVvWedA8SFx7Vr/njGsrPXIGOLZ2ny1TR3t0I0/GuhawV37KtKtkhLXVmILKNLL2bbrxkmBBv7XdtiYQtZWk0XHtUJz2sb3EasNR6f7xbASwcrRxHc7lPHH7/E0W2LJI7nvtt2/vZt1NuIpaz1nQPuPTf77xD77yf/S5Ob/ulXfSYPV8WnbNizvYf/7pWi0XN3i9W32ky+b1n/cH/9Xsfsau8tcCX+poa7uv7iTEevuxodE6eqtMxbpPjfcR24iKVDfAsmNFGSfHY+VNCOuPSJrfAx7tE0TYmghixW79xefTrqJ3tegpXfFXOncjeaRpO5CqZX9GeqWvCVrK3NcKxRrQtt0YVQsJwZ6yIpaRnLOqA6Lotqs5dhUv1QFPXDH3q93D99ni6Va88VziW2BktV3+LlLhfeZ0OXEZGlisRKtv0Ew3p5ENrBbe2k3dmvzW1AtVCpJbuLMpZIlSrOnECaKGhJXLrLWxpBrmwbH0EZ9nS9/w001KufmHkvstWJ7aaW0iCWarD1/eF76bUrb8pasrcqerVCswW3ThVFxzxiKItgcAz1kTfYk5IKbln6bJmdUTc5ajk01s0hR9vxyYInF80d6t+ZPnXs4t8XL29zofPE93VmiUcF3x4rvNaXLKYk1tYGk0BUNm4G2PWmQaOQurOeG1s/dQZCs7PP8Ya66K4Hb45pH1uIY5m3T6BjaKCyYCKWUe2Is0JUCSaGu9biESCKtTfDjUhtbVOp0kNvylqytyl6tUKzRbdOFUXGvGDZEsC0GesiyqGCCs1HJdzdyRtXkrOXYVBsbSEolPb67r8SNJOtnZym78qeGPby+xUvb3Oh8eWBX8nmF+Zm+N78O9NRusn890WetGTdwvKPv6dO6N0KS9DT/hUXS7Oq/3VjPrX8cMT9Ft95Ke43d2I0kizS1UPl5isP8rMU20Ci33Pzh5cm8nXx4ov+/KCd2xjWP7MgY/oae22tvMTzSd3Nr3bttjozhqdd2uL8zfUffr3sjJEl/KTeCLNr3b5awnx7Nh9rQfqeE6H9C/zebYiPfzj+uv2p/4HEtT/Jf7MhbX1n7pYZkbXNG9nu1Qikju98R5Z5HrEbl1xO9OuDotP3YtC2GpVbQP/B6b8yT4xex05e9Hk83jeQ/VX/bltLv/O69R/pebq3HnlHtm7VnuvSaAe0/Ni3lV2lKHLPnVmcQX/6waVf+rH405Tvbv1vw3bU5z5e2wle+SNK7nkfryQN3fvxScpufKLq7Udxu7j6fsoGmjqvYS1Y60uLJlODuZN9iTaTsU5v5ta6N+7Hnzi1eJMzy8wmWaOJGFkpZsuU/u/lww6eh94troBc74goUubHF2RyA+at494/hvxd0wvvHEC/NV1gQw1LrLF+HvH8ML3y2QxfYy9wIkrWvReq7972vKdDdQSJ1f6uESHIjYG5cvNG5z5d3HTSm+Mra/0PWLrtvK5QwsnsdUXbFtWVcb0x+2UAfbItB2thHViLYEcNSK+g3Vx+e89gO5fiWz+NpNSP5fdu2hH7nde/tPhvZ/4zqgKx9pV/zmgGtPzat5FdZyhyz97M1f7R+3bfMbD98i4/JF0n6wO9o7f+lXWMlBZNYFN8+joVFGkSaSBZZolj9fZ9WsiD7JHaRnrl9brGmbiQpmp/QV/Vuu/W4AiWa2K20Glt7YpA2tU5jY2inScGrXZJ7ThC1lUuzp75Tef3IcW68fuCwcPnTVe/2HlPI2hKdysj+3qZxvUUxbBzZCyLYHgM9ZFllI/ncAUftIu3J2YPOqJqStRybWqAwfxq+h5uXL55LbJeuT0dkA414IfxmFtlAscLsIDRRYIlSN9KlpvPPU0Y7PtvpZZ8K5m5xuNvnFupat+bMafH4f5kHt61xSW6oUGM3zmJbRNamGPKtk2+bBsbQYpe6Wv7AzqK152o8cUM90nM9dqV8GOjGCtYelbmS109L8/YYU8ja0h3YCsUa2DaFcX28cVxvTwybR/aCCDbHQA9ZU+FIfo+jdpE25ewBZ1T1Zy3HpvpYbANJyeIDL4sVKbLYegqz72/Nn6r38PoWF2xzs/OlhDe73WqgIPf+11v/62j/n01vclOgWKGTIiVOi7e26Xrr0rI3jyvM/k62vXWyjrcHzuMKFKifj+0usqNiKP3dfPkYVltn0TbNaYdu/FFft4rmb1NN9LKKd1OWEkmgl9k7HW+cFOpGV97XcdCYQtaW1NL3bIVNv9WUttke1+ZxvVEx7Dg6bWqd1Qi2x8B7sQuW2Ct7JL9v225YWmvORvY/ozooa0t+L/ZaFI0/NnXlvdh7/NbG/Knnvdj7b/Fx+XL/9W/74/+92HLPJN3alZ7ZlW6zr7Enl7qxm1qoRJHd5D6LGVm87beyv+9uf4i2Xo0LS53HeEtcknrqK1Bo8XxCgiyy9sSw1jrztml+DO3iLnWha7vW39U/sVv19Nzn82GVRpLqmUK7tYF+zK51o6HfWTC2r7twTCFrK7WrFTb9VvZ3Y9smGxU3justimHjyL4WwfYY6CFr3LCukXz3Ubv4t7K/G5+zB5xRNTBrOTY10Ob8aeoebnC++H5p1yy8C11YrL+tUXWnkd3ipmvvkRxZ3yb73XBvWyeit0F5N6juEdnl2ncKI2t0DCuts6ltmhxDW7ixHlukn9Z39d9KfXK5/EhSnVugSD/Qv63lZIasbYB9W6FYc9tm33G9yTH46SOlR1DFmydKmD257pH8mJ7X6Jz10vPa3+9Kj8H3LPvFqnhfwA6be0ZTj/6NzJdMKSW2JLmxfdTWK07N5C6X58bbItj8lJMFGjbtyfjCyFoVw4a2aVUMzeUmXXnCyqUaV/Dij323hqxtgAPG9Za1TRfy69AYyo/Afb7ufXLEtjdqJD+xM6pas7bsCMqPwf2duvdJdYr3fvOyZNcWN6HfllZiw799r31t+4zYpU2cEXA9srbFUNQ2bYsBp4asbYL972loW9t0Ib8Oi6GJEWCTUzqjalvWdmHsaK/Cvd/oPdzUfCnhWWwAAAAAAE4RJTYAAAAAAF5wo3hdPl/BpCX7+ZLXpX1Ov2T94xdzoDP9R49L+2H9jEXHL+ZALX7GDo3wpRrGlHfqDrpx6miFYn5HlLdqictvfr2r9yo/Or2l3614jaepjrYtdua1xb9fy9nImecJ7zg24SRRYtfEPa17C0qK6xfq3gIPMXxT36x7G4BDuR+pewvQ3VZwP1H3FniI4e/XvQUoS1fb1v0nfbHubfAQRUdHRWA7bhQHAAAAAMALSmwAAAAAALygxAYAAAAAwAtKbAAAAAAAvKDEBgAAAADAC0psAAAAAAC8oMQGAAAAAMALSmwAAAAAALygxAYAAAAAwAtKbAAAAAAAvKDEBgAAAADAC0psAAAAAAC8oMQGAAAAAMALSmwAAAAAALygxAYAAAAAwAtKbAAAAAAAvKDEBgAAAADAC0psAAAAAAC8oMQGAAAAAMALSmwAAAAAALygxAYAAAAAwAtKbAAAAAAAvKDEBgAAAADAC0psAAAAAAC8oMQGAAAAAMALSmwAAAAAALygxAYAAAAAwAtKbAAAAAAAvKDEBgAAAADAC0psAAAAAAC8oMQGAAAAAMALSmwAAAAAALygxAYAAAAAwAtKbAAAAAAAvKDEBgAAAADAC0psAAAAAAC8oMQGAAAAAMCLB3VvwH3YN/SdGlb7jvu5uiMHAAAAADRXK0tsvauv17DWX6o7bAAAAABAk7WzxP7UjatfqfXrDhsAAAAA0GQ8iw0AAAAAgBcnU2JbeNj/WmBB3dsMAAAAAGiTdt4ovsQC3d3CnWrsJoU/09dw60J6usiWFc1uQnep9W3o0rqjAwAAAAC0RQdKbJfqwpyeuYkF6lvPna/+hCWabCuWLVAgSdaTlNqNRm4oaaj+rPAGAAAAAGC3DpTYkkVK3URyqV3qtQ3XrmT33POtC0g0lCxU6C4kk640lFxqqUXFV8UBAAAAAFjVjWexY93NMJ7Miu08i7SrTJ4V0oH6FkhupMBiSdJYSd2hAQAAAADaoqQS2xJ7rdheWlRJFFkRbbESrV+vjhcltg3s1l7ajd3ajQ2y74VKJclNnLlUskRp9jz2RNVsPwAAAACgA0q5UdwCXSmQFOpajyuIItbUBpLCwhvCA2XPYVuikbuwnhta313O/z9ZmQqtl3sCm1nFAQAAAAB7emD9EsrIs/kyQ/ua/sT78p/kv7BIcrP5wG+s59ZnDo/ubiN3I8kiTS3UNPf/oct9ZYNssrOZ/CRpT+6uezfG2/qsXtW9ER59Wd+qexOO1IUW+Sv6qIQ+e5wzfaxPSl9LNfnXxCxv4jYdppoMIZr76MKo2OYWaVLvbvp+bNK+Ipp2x1D/uPfk+EXsdKavZg/W+llavb6gr3it86YPNC6hxH6on83+9al+u4TdsHytevEk9t3M4IEiN7Y4m0d8+Unsnju3eFE6Lz+pbYkmbmShlJXd+X3zer6epnioh/rDujfCo1f6oO5NOFIXWuTbDYzgC3qjN6WvpZr8a2KWN3GbDlNNhhDNfXRhVGxzizSpdzd9PzZpXxFNu2Oof9x7fvwidvpYU73wtrSnCivY5s3e6COvdV76oJwZs+1cV5JSnbsSylJ7vfTlokiOdCHZe/qiRnari/WXblmQNWB+grT5LeMWa+omkiI3uttBuV9+XUYsyGH/ok7V5F8Ts7yJ2wTAB3r3/rq1r7oQTRdiqMlKpVSOT/TCX2Vk0ucq2ObN3uiV3zqvpOnO3FCP9FyP56VqSSyygWKF2Y0KEwWW6GM3VKixG89uH9dIi9sYelmHzU1jdvfGbAt1rVtz5rSYCI1XdgEAAAAA9lTae7FdWsWnT26iSe5K9XNFmiq1YDaL+Oyt1m5i/flPDF0qubFlT19bsiii3VSPVhafqOSPCAAAAAAA3VFaiV2HWVmfTeAW2uJlXSOLs9dwZVes5xOcRe5iywLDcm6jBwAAAAB0UadK7Jnc67juvjOyvk1cuvp92zrRmw20rfwGAAAAgGb5IY9zfW9ypocel/ZQZxVs82ZP9bbfBXawxC7iLpdnDs8EGm76DQtmN5UDAAAAQEv8b1VRrvqsk1Kpkm3e5O2lFzp7YK7GaO690TeuisnoG7FWAAAAAEBblDSjOAAAAAAAp4YSGwAAAAAAL9r5LPZbtTwQ/1bdYQMAAAAAmuzPAS4xa5ZT2ndYAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE5LTA1LTI5VDEzOjU1OjExKzAwOjAwPrnvOAAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxOS0wNS0yOVQxMzo1NToxMSswMDowME/kV4QAAAAUdEVYdHBkZjpWZXJzaW9uAFBERi0xLjUgBVwLOQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc7 = qc3.resolve_gates([\"CNOT\", \"RZ\", \"RX\"])\n",
+    "qc7.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = False\\begin{equation*}\\left(\\begin{array}{*{11}c}(0.354-0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0\\\\(0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354+0.354j)\\\\0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j)\\\\(-0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (-0.354+0.354j) & 0.0 & (0.354-0.354j) & 0.0\\\\(0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j) & 0.0\\\\0.0 & (0.354+0.354j) & 0.0 & (-0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (-0.354+0.354j)\\\\0.0 & (0.354-0.354j) & 0.0 & (0.354-0.354j) & 0.0 & (0.354+0.354j) & 0.0 & (0.354+0.354j)\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = False\n",
+       "Qobj data =\n",
+       "[[ 0.35355339-0.35355339j  0.        +0.j         -0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "  -0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.35355339+0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339-0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.        +0.j         -0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j         -0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j]\n",
+       " [ 0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339+0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339-0.35355339j]\n",
+       " [-0.35355339-0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j         -0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j        ]\n",
+       " [ 0.35355339-0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "   0.35355339+0.35355339j  0.        +0.j        ]\n",
+       " [ 0.        +0.j          0.35355339+0.35355339j  0.        +0.j\n",
+       "  -0.35355339-0.35355339j  0.        +0.j          0.35355339-0.35355339j\n",
+       "   0.        +0.j         -0.35355339+0.35355339j]\n",
+       " [ 0.        +0.j          0.35355339-0.35355339j  0.        +0.j\n",
+       "   0.35355339-0.35355339j  0.        +0.j          0.35355339+0.35355339j\n",
+       "   0.        +0.j          0.35355339+0.35355339j]]"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U7 = gate_sequence_product(qc7.propagators())\n",
+    "U7"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Resolving non-adjacent interactions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Interactions between non-adjacent qubits can be resolved by QubitCircuit to a series of adjacent interactions, which is useful for systems such as spin chain models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFwAAABeCAQAAAAELrvYAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NNwyn/rzyAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAYdJREFUeNrt2jFSwkAYhuF3HUotgo02OoOFB4hHCJU1rWVqW2/gFbC01CNsjhCOkLR2WDgWVGsBBLD+f2aZ+d40W2UfIAvM7IaEfWFCTcUdSz55S73DFJw5sGdEeqa0PNATQ+0BJxlflHRMEgliIkFBS2U9S3KAt5SbUdy9FHu48aMSSvq0+PeZLmhCZf2kjEJJYXi/Z34G5HgYjXgJpuzUjKhM4TesGODD6J5LbN/zxn5pfgzjOIzm9svTfnF2x1mc9jesaCl28JP5OkxQ01FTELdj+zlc4AkmvNLxS8d8/WNkfwWP/yrrQkxTt5t7/Fc5ToILLnimCS644JkmuOCCZ5rgggueaYILLnimCS644JkmuOCCZ9rJwq0PIex3ZX9mYpv9IYQDuPHBg/0a7XMeO8EFFzzTBBdc8EwTXHDBM01wwQXPNMEFFzzTBBdc8EwTXHDBM03ww8IsLKlCF0oveMBjg/acdy4A+OLJg+21QXu7YcM1j6wc5D4btKFguRl+p7HDBMAfWxecZ7mhoQ4AAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDUtMjlUMTM6NTU6MTIrMDA6MDAPUfWlAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTA1LTI5VDEzOjU1OjEyKzAwOjAwfgxNGQAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNSAFXAs5AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc8 = QubitCircuit(3)\n",
+    "qc8.add_gate(\"CNOT\", 2, 0)\n",
+    "qc8.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[1. 0. 0. 0. 0. 0. 0. 0.]\n",
+       " [0. 1. 0. 0. 0. 0. 0. 0.]\n",
+       " [0. 0. 1. 0. 0. 0. 0. 0.]\n",
+       " [0. 0. 0. 1. 0. 0. 0. 0.]\n",
+       " [0. 0. 0. 0. 0. 1. 0. 0.]\n",
+       " [0. 0. 0. 0. 1. 0. 0. 0.]\n",
+       " [0. 0. 0. 0. 0. 0. 0. 1.]\n",
+       " [0. 0. 0. 0. 0. 0. 1. 0.]]"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U8 = gate_sequence_product(qc8.propagators())\n",
+    "U8"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAKkAAABeCAQAAADyS/wFAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NNw3Q+YxkAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAAuxJREFUeNrt3TFrE2Ecx/HvoxGXOBxF6FYpuCkol5dwi4Mg1ICCgiCk+AqSzfUcpCIuCXRxbEEUdBCzOPUNiFs6q2AK0qU4PA45W4uSFPkd9xR+ny5phod/vtylHfpvQiR9oaDgLlPeM4q7TU+zyJmmB1gkZKGkZJdXPGWXD6Hf9ESLJJ+UIcROHHHAlziiw2oomx5pvsSThi7EwdH3cY8B3ZA3Pdc8iSelx+D4E7OoTY81TyvkZMLzrvKNr8LzrrEaVgFY4XqYPfeTtTBOd+YWhTTpTSZ8Fp53lqJ6dAlYqh5fPHw2xZmj9IuSQnre5O+TydlKeebU30vH//ilqY/ytpdLPemA3vGf76FHFkdNjzVP4knjHutsHV2poaTHetNTzddqeoBF4jh0KMOEJW6HwHbsND3RIsknra5UwgYf4+umZzmJxG/8Pxyw3/QIJ3N6kp4aTirnpHJOKuekck4q56RyTirnpHJOKuekck4q56RyTirnpHJOKuekck4q56RyTirnpHJOKuekck4q56RyTirnpHJOKuekck4q56RyTirnpHJOKuekcrKkRyvdIUt/Z77OqXVX6XY1XpsS8apX6IYpfV7WsDReTR0y4dTCXcyckg3ekon3UjOm1cOJ9uRq6h1uMdRNHegLN51XWGOHHfGVtMKdw8fPOBCfDg+4wEh3bouxLGmbK3zinHxptn2Y9AfvxGdDm3u8YZlN2YnC23NIRskjSvnN2SMSmdKVn5wxZIOCXDe1briSbLbbTk6vhpdeqN+jf08928fXTR20/ycqlIxj0tvy9c/sX/XlnFTOSeWcVM5J5ZxUzknlnFTOSeWcVM5J5ZxUzknlnFTOSeWcVM5J5ZxUzknlnFTOSeWcVM5J5ZxUzknlnFTOSeWcVM5J5ZxUzknlnFTOSeW8Siaf+lSsktWohlUy4d/qh5wu57nM/bjXSJ7/nfoFT7jBQDW19nNIv/OY5+Shjte+zH5Nn/gU2eShbupfFQP0x9WZofIAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDUtMjlUMTM6NTU6MTMrMDA6MDCpJv4RAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTA1LTI5VDEzOjU1OjEzKzAwOjAw2HtGrQAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNSAFXAs5AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc9 = qc8.adjacent_gates()\n",
+    "qc9.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[1. 0. 0. 0. 0. 0. 0. 0.]\n",
+       " [0. 1. 0. 0. 0. 0. 0. 0.]\n",
+       " [0. 0. 1. 0. 0. 0. 0. 0.]\n",
+       " [0. 0. 0. 1. 0. 0. 0. 0.]\n",
+       " [0. 0. 0. 0. 0. 1. 0. 0.]\n",
+       " [0. 0. 0. 0. 1. 0. 0. 0.]\n",
+       " [0. 0. 0. 0. 0. 0. 0. 1.]\n",
+       " [0. 0. 0. 0. 0. 0. 1. 0.]]"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U9 = gate_sequence_product(qc9.propagators())\n",
+    "U9"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAByCAQAAADq3y4cAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAAAGQAAABkAA+Wxd0AAAAHdElNRQfjBR0NNw3Q+YxkAAAKeHpUWHRSYXcgcHJvZmlsZSB0eXBlIGljYwAAWIWdl22SZKkNRf+zCi+BTwktBwSK8P434ENWd0+33TNjOyuIzHoPhJCu7hXpn+7pH3zqUEn5fVbJPz7167ccudq1jtq115rHHDZWzX/2SVKkadPcy8gjd//TmX/xCXZ9Hv1w57R6/h9DH4/+x/lLugxt0r758u0E6omDZa3aP/8XnV8v6lQlQvn78/XNTulSZf/xfPfvzxPh/ITx63+fPxboz8+P/2Ho5+eRfzbUycyXqzV/7TCzY+j3z/9kfvr1zN8/tfbyDiwmwvtJ+puECMdV4Y2MmrV9h0a33lJvTCJKbxrLXMbvo/x3ptN/2v5vTf/6+dv06zv6/JYlPh0/yJqxkYkKb9j+efTXcWi15VYakP1diUQbD8zlu0eliPvf1dL3z+/mSaz6OVqb8RWHZr+fWM3e99b5mVfmWf8+72Oo9m/IjfmJxRYPED/Ikvxi8Uek8jP4FsUDI8MwVC6m2isLBkVL0jJ1k9v+WtlZ9HbqLBo8GHg3WPOwJ/MRDil5R1N9RQc8CdrEg4mBdxLDgGHAMLAwsHi4MLDrOySDNc4aZ41vDD3mOCw6GGBevvy+++M1TMPY5OX9KeOQmsYwRuRSB4P3DY9Km4zLUXkIsRWyXnC/YKMIi4V3yju8LhMjeFyMOXhboNaCp2UXDG1+4GJxvg/fh+/L9+U7WBCL4mwMh4Y741AvwghCO8lUYXA0qpnBS3avykNlIdmr8+ZqTCTHdWFks5gNq29yMnJ9OSIEFei0l/6WN+AVklXyo9rGLtQbI3KDd5rwTvFJL4Djf+N/jDcC3zb/u+Z2Goaw3K7nFka2hcJpmfphHApr594nCEAXSHfH447BPp36XqCCd3javafcDxOIyYNJjwvUTh7F8yAboy2gA9zHzIOjD6AygMjAq7EYG+lxxhkJbPGDNH/+OKJUzY/IBU+E7ImsLLrBnmexk2VFFn84LFluo9DgnKwpK5hQdtd24IzIVD4Y7VnZWakxJdC6eX4gLjbVmFDrBr+RJ1Uwu+Q5VgLMN084ZOLuXAtg8z+L5tU8AaMBXgN4xjGNjUx6NrVsk98g3gi4eaRs7GIsWKXkxbEWni0gsTjSomwWEFhkaBGLhZqseHnmD0Ld0MWGk7ZQtJu620ze+5UP3wR+k0EvQLCu7EDBh2cH3Q62fGn2V2YA1zF63l9Fsk9/pbbyIS6HiQfIH2fC4TfxuMDhgr5L9i7Huhr52qYcJV9CcO+lLPEoOH8A84AaAlQHsYrdUOPIcV95E6VKBjqMK5xfcdk2bvP86FtYKOTE4LsHfHtKmV7KIlpupdzJ4bRQV6X2Uar0QumUulqpzriQ+SP0ykDXCuIIATAWmPYBEQxKU0qn8Ho3RHqVPnfp60AOlz0hh1LLaHRCQwqyAVnsVMY+hVO9ait0CEVYLOJFZhTZFUd5Fqso1KC9FJVBr2FF1y1gq2homQVDFHqZvJxzlbkCYuc3Cz+Uw5FMdjFOahvonkNj0suqqyxCs1Sho1uARiqLgOJ42W2XzTE3Bjee7LPKYyAgUHzwrbs48XH34gT4QFqHKj76KMwSHUsrB2O3SLl4d4nJtV4ugLrXSpCNaLeE8JvnsaPEXfVDpcSewqvAPIE6SAOyI1UQ4OTQbL+Ipt/Kqlqr1jpGrZOfK2o9B81ZFd6qcFVt1mvzmmqLx5ZRez90Eo7G7drPetVVB5OHMJD64YxAyetTc8bU17xVuZP84pF2q6pUGQb0OOp26mxB8wdsFo6cXu2JLUYJPKJ7KmxC8eAgbcxio0X6oeOARGrdTaBlq5uJIKI+avNm1eVWx6AfhTO9HuJyVOph43PBJaC53VPFMzhcKzVTOSBcvmpYqcFRImCuNmAvim9RvWdTB0C5kz5CVDbfURu+pValtWob3u+Nma1Bzk2jtT1bI2UdX+mRWrfb+pl0Mq0N+HlM+jOvbcShODQ1UYK/bpNriEVv+kTDvOnRNktvNCBtTm/T52tWPkkyNrLNwQO6w8zSnhpHRVmiceK2BViu1fadZFQbbV9zjuS3tVNro1oaOG0wTLso0mXTiyLBJIn8lBZMoFlqcSvK2KjZ/ijykQ+hBYVCRS8HpRd/UCpcr3sQUCUe7KSHrhaJ6shhpx3tc3Uq/JEGUkZDDSmPc+nSa389oazdJZA2oqS6gR0Sh2BNJLtTyH1Cj0blmBDTZZ1OhrxoX3o6jvQN/Dfx3hjeeE39dZLafa8OpDqzUj9GMo73SxNw5Xag8KWVtMrEssd5Qg9hKxex/ageqkAKoYNBYQ5AMCqXGlCnA1ob5BFhXYOAjd6xSmPZz6bK5hjKQZ1qgVcFaZVlgy55EIyhVBIqnsYEglPPmL6HwTImBuEheVnHYtlajBhjE7VtjIvNxoDE/Mg4eHt0pnHcBtQ0rvi4+wwoHwUvAwGg1cIJLqwIG844/MubBY3iWCWi1bjkoOCPswV0SUNb+ku6denXQA9bGUV+VYTflKBQ5YKsixoYZg6FLaizzOvyLjVitsTiIWVy9KBHUNnsvBffEfip4otrK+J+6DHONqFW5cqW66CBiAdHk4DTaccQevqWS24AfLGh9AgkmGpeOEIH2YgE9QdC+9fd0skSZEPnrsQmvXOpwOwSXD9pgnQ3BAah4Lo+mWx1qU3ahgtrcbEksTQ5XeF33dQRvKo+MeRPVbjfUEP6+tcLBV4mwA50MF3j0mV1LrtrvpZiolGz+IFEMkwHAUeHEjRNqhT9PBOsz34pdhaNtemOXnQrgeGW9c5kMbE4pxhkcKdB2mb4GndSlmkuXxOpn8Rw7vDpAmPw7EBdhzUnYt5Pcu6MhmwafTO9G+0a3QbSQvNZ1kyGfEDay9DyVywGl0A59FSToqNOxggbbp8yJL1GB2UE04iDze42N47VnvAum4UDgmnrAGq4fq8wZNCcOR5qB4ShQobu2V0XtBwOui2CFk9ob89MdAiKtAr0zjBZEDSFz0ApO1VFmVOAc43FXrQqBGCBGVB2F16tiZBM2uMFwTLFaGZ8LUQfRVmbMtvXkHRfTid4Or0IWn7RjovsP/zi0X53O0qSrmulTRuyy0GwOorvMH0j9utyQurUqOTS9piL/gy/1TbEBujmxhtKm/I+3Gbgo20shqX32gNLlx8PZ2W77dfw7ENrywmgcTgtUH6UNIKmklYyXzoKURqHlmCZQPWQBIikHS4DtP3QrY++ORlo6Fz9nRtHfw0J+GjH53ZHP9jLaFCmE4vksIVvbrFYcg7iKJbDZwiH+H2326YeHIDbzMmbtq05h6ENbXG4LR3Y/iA3iTgafkBE/Z5xiNYYRw4sjj3icKYgixdsCg0xeSddZ8Um9jS/3EJ8LtqvnA4zkHA/tDwnaA9icbNBLvPmcee64/Q3Axk7GyfbhbsuMnJ7OFUIzedzxSRd+OICACSRNmA7PRbYPyQUUl0X0oRcNvGGWi997z3mdAnzktcbKF84ffSYie57RKFfKBH0MoSkWEBJ0REQdAe2hnvPDZET8pJGozmZMwEdrQ4loAGzpFi08ls1yCeFMomgxaFGbt9xj8ORlG1E+hftkQTIS62KtQAAByRJREFUeNrt3cGOI1cVxvH/iUZCQoFQs4EdqHqEUEQSERtpFknYVC9ggdi4xRPYj+B+hOotK9wvgGQvQLC0kUImyiKyiRjEAohbjAgRCKmdjIasIl0WXS67myMhTddxTU2+Xy36thd1763TX91b5UVbQkRueqHtAQhYbhNb26e2trkN2h6NgILxDLAhc1bpiPfTESPGVrY9IlEwWmc9xvTT+dVv6SL1yRSN9ikYbSsZpc21T04ZWN72sL7oFIxWWUaWFtc/SxvO0ZNGy+7YmCzo3K/yMHz8X+Jb/Dm8l2/yCZ+GnPnlvY3Tvbr1Mq9aVFVe4w9BZ955ia/xKLyXuKqQTu+wCAvGH/lX2EXZ+Qb/PEAfT3gScubPeIntinFctz7jyyye9pT/xyP+GnTmnRd5sdNVAUzfY7TL1umoas3TcdUqudg+jks79IzRtoWNr39gOQNmbQ/ri07BaNspQyt2v1rGlNMb76nk4BSMlqUNJ5RWWg8styFLZknrRev0jPFMsDE9fswDVpyni7ZHIwrGM2T38C3t01ZKxKFgiDgUDBGHgiHiUDBEHAqGiEPBEHEoGCIOBUPEoWCIOBQMEYeCIeJQMEQcCoaIQ8EQcSgYIg4FQ8ShYIg4FAwRh4Ih4lAwRBwKhohDwRBxKBgiDgVDxKFgiDgUDBGHgiHiUDBEHAqGiEPBEHEoGCIOBUPEoWCIOBQMEYeCIeJQMEQcd9oewG1Yxg/I+V1atT0S2bGMH/F1ftXtf8vc2WBYRknBB7zCfesxSou2RyRgORMyPuaIH1rGqLu3rI5upSxnzkU64uf8Mp1wQmll22MS6zHnPPX5Gb9Jx5wytWHbY3paXV0xJpyl2faXtKJvSyu0arTJMqac7NaItLA+S1t0c0sVtGLYwC4t2dp6MWdns4tFZUTImhE7k/1eKA7RS+Bchsyub53ShrPOViUFHGRcVs11yPlLBlWroKw/XZJ1bSbPUy9M6TlVCejrENfLmJA3nra7vF633+bzxs//Fu9VZ73LXT6sPr3PR3zUsZk8T728yYO6p11V3uDdzs2EdBx1b9o2L0POP6Fw7k1z8q7N5HnqZXf9D7BihF+vkGeMtGEEwPZn01YUNz+yjLz5x7x6Jo+DZnK9l6jrdZhevKoUBLywPUhVAu9Pq+b3/PW511f72d29iSnjsN5+wU+irtNeL0XU9TpgVfIbVVlu1/auVSXse4y04TJtws49Ymr1/ckyKyGdhfX2iCcx597vJS2irte1uURW5ZTp7j2RZTZlEfUKPboqHf0eIy3shImt+A/3rGTALJ20PSZJM9swtRkv8B0rGXAedbOK19FvviGtUp8Z93iNC47TadvjEYC0oM+KV/guF/S7G4vOrhhX0sKgSOdtj0N20oaZbbpflc6uGCKRFAwRh4Ih4lAwRBwKhohDwRBxKBgiDgVDxKFgiDgUDBGHgiHiUDBEHAqGiEPBEHEoGCIOBUPEoWCIOBQMEYeCIeJQMEQcCoaIQ8EQcSgYIg4FQ8ShYIg4FAwRh4Ih4lAwRBwKhohDwRBxKBgiDgVDxKFgiDgUDBGHgiHiUDBEHAqGiCPov7ZaQcF9K+P+AfqhWE7BT+lbziJdtD2aW85lQI/7VjJLq7bHcsuZ5AyqqszSJqKHgBXDcpsz5IK/ccHQ5pZHX6Y4NmZOzkPeIWduw7bHc4uZ9GxJwYq/c0FpU8vaHtEt5lIyBx7ye3LmVoR0kho+yFgzSCSYJxIMWJM13UvdW0EZde4EJVOyBCVFgoxpZG+RBzlrir2qjDtclSmTvar0WF79vTV7NL9iTDhPs73gzThjGnTrCGUFRTrZLdRpw4iB9doe11OZMtrf1KYzZozbHtTTsAFZGu1VZcUJZcD61/idaVm353VrSR5y7xjwmMSaXtCdqahaZd0adHHNoGDiVGUd1FtsVeq/pb2qlIyb7qfpFaPAe9ieMWg80VjGhK8AedCK1HNeHCyI2dHGKvAethcRu/PwquC8ApnR+DpuTGjy4bjPY/5Stb/HB1Xr23yVZeNX6C6v1+23+bzx87/Jg6p1j0suq/ZbvNN4T9tePgw68/f5mH9U7V1V+nwS0GN0VXbXf78qb/Buk52k4+aXUW/RLiMej8jq5mXIol0/nu4t2vluVt05GO+2GntVmUZsduKrUrd2VdnbKjZ1NLyVSjOKmw9CljEg4NuMtGEEwPZn02b87+vZYcRMwjkzsZxexLcZ4VVZORvAIc3PJODuNL1+b6KMe2Alo4h67UjG+upBb3tvohf5kjPy2NWgrso8YhU/QFXqGtRVGUSs4hFDn1Rv/+fVu/8Obj6qmQyuvpOp3piPo960HGAmGUvKuio58+Y3Hweby/DqO5mqKuX29tVwL2FDn/Jvpqybf5F20CLkzFnyJ37N+uprpe4elFVV5tuvYLt60Kuq8lvWV3Fv/vgvoLfYzVhw5u8AAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDUtMjlUMTM6NTU6MTMrMDA6MDCpJv4RAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTA1LTI5VDEzOjU1OjEzKzAwOjAw2HtGrQAAABR0RVh0cGRmOlZlcnNpb24AUERGLTEuNSAFXAs5AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc10 = qc9.resolve_gates(\"CNOT\")\n",
+    "qc10.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = True\\begin{equation*}\\left(\\begin{array}{*{11}c}1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0 & 0.0 & 0.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0\\\\0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 0.0 & 1.0 & 0.0\\\\\\end{array}\\right)\\end{equation*}"
+      ],
+      "text/plain": [
+       "Quantum object: dims = [[2, 2, 2], [2, 2, 2]], shape = (8, 8), type = oper, isherm = True\n",
+       "Qobj data =\n",
+       "[[1. 0. 0. 0. 0. 0. 0. 0.]\n",
+       " [0. 1. 0. 0. 0. 0. 0. 0.]\n",
+       " [0. 0. 1. 0. 0. 0. 0. 0.]\n",
+       " [0. 0. 0. 1. 0. 0. 0. 0.]\n",
+       " [0. 0. 0. 0. 0. 1. 0. 0.]\n",
+       " [0. 0. 0. 0. 1. 0. 0. 0.]\n",
+       " [0. 0. 0. 0. 0. 0. 0. 1.]\n",
+       " [0. 0. 0. 0. 0. 0. 1. 0.]]"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U10 = gate_sequence_product(qc10.propagators())\n",
+    "U10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Software versions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>Software</th><th>Version</th></tr><tr><td>QuTiP</td><td>4.4.0.dev0+723960fe</td></tr><tr><td>Numpy</td><td>1.15.0</td></tr><tr><td>SciPy</td><td>1.3.0</td></tr><tr><td>matplotlib</td><td>3.0.2</td></tr><tr><td>Cython</td><td>0.29.6</td></tr><tr><td>Number of CPUs</td><td>6</td></tr><tr><td>BLAS Info</td><td>INTEL MKL</td></tr><tr><td>IPython</td><td>7.2.0</td></tr><tr><td>Python</td><td>3.7.2 (default, Dec 29 2018, 00:00:04) \n",
+       "[Clang 4.0.1 (tags/RELEASE_401/final)]</td></tr><tr><td>OS</td><td>posix [darwin]</td></tr><tr><td colspan='2'>Wed May 29 15:55:13 2019 CEST</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from qutip.ipynbtools import version_table\n",
+    "version_table()"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Many times users are confused why their circuits are not displayed when the run the QIP examples. This is because we do not have ImageMagick as an install requirement but still use it to render circuits. I added this message to the tutorial but maybe I should add it too in the code with a check if ImageMagick is installed. Also, the rendering in the notebook was done from static images which could be confusing if someone is following the code.