### PR TITLE
Fix break in Plotting in Python Using Matplotlib and some CSS fixes

### DIFF
--- a/docs/styles/guide.css
+++ b/docs/styles/guide.css
@@ -1,333 +1,356 @@
 <style>
-@import url('http://fonts.googleapis.com/css?family=Source+Sans+Pro');
-@import url('http://fonts.googleapis.com/css?family=Source+Code+Pro');
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro');
+@import url('https://fonts.googleapis.com/css?family=Source+Code+Pro');
 
 body {
-    -webkit-font-smoothing: antialiased;
-    font-family: "Source Sans Pro", Helvetica, Arial, Verdana, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro', Helvetica, Arial, Verdana, sans-serif;
 }
 
-
-div.cell{
-    width:768px;
-    margin-left:10% !important;
-    margin-right:auto;
+div.cell {
+  width: 768px;
+  margin-left: 10% !important;
+  margin-right: auto;
 }
 h1 {
-    font-family: "Source Sans Pro", ,Helvetica, Arial, serif;
-
+  font-family: 'Source Sans Pro', Helvetica, Arial, serif;
 }
 
-h4{
-    font-family: "Source Sans Pro", Helvetica, Arial, serif;
-	margin-top:12px;
-    margin-bottom: 3px;
-   }
-
-
-div.text_cell_render{
-    font-family: "Source Sans Pro", Helvetica, Arial, sans-serif;
-    line-height: 125%;
-    font-size: 110%;
-    width:768px;
-    margin-left:auto;
-    margin-right:auto;
+h4 {
+  font-family: 'Source Sans Pro', Helvetica, Arial, serif;
+  margin-top: 12px;
+  margin-bottom: 3px;
 }
 
-div.cell.code_cell { /* area that contains code + output */
-    background: #fff;
-    border: none;
-    border-radius: 10px;
-    padding-top: 1ex;
+div.text_cell_render {
+  font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif;
+  line-height: 125%;
+  font-size: 110%;
+  width: 768px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
-div.input_area { /* box around box with code */
-    border: none;
-    background: #f5f5f5;
-    border: 1px solid #ccc;
-    border-radius: 10px;
-    padding-top: 0.5ex;
-    padding-bottom: 0.5ex;
-    padding-left: 0.5em;
+div.cell.code_cell {
+  /* area that contains code + output */
+  background: #fff;
+  border: none;
+  border-radius: 10px;
+  padding-top: 1ex;
 }
 
-div.prompt { /* remove In/Out prompt */
-    display: none;
+div.input_area {
+  /* box around box with code */
+  border: none;
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 10px;
+  padding-top: 0.5ex;
+  padding-bottom: 0.5ex;
+  padding-left: 0.5em;
 }
 
-div.cell.border-box-sizing.code_cell.running { 
-    /* draw border around running cells */
-    border: 3px dotted #f33;
+div.prompt {
+  /* remove In/Out prompt */
+  display: none;
 }
 
-.CodeMirror{
-        font-family: "Source Code Pro", Consolas, monospace;
+div.cell.border-box-sizing.code_cell.running {
+  /* draw border around running cells */
+  border: 3px dotted #f33;
 }
-.prompt{
-    display: None;
+
+.CodeMirror {
+  font-family: 'Source Code Pro', Consolas, monospace;
+}
+.prompt {
+  display: None;
 }
 .text_cell_render h5 {
-    font-family: "Source Sans Pro", Helvetica, Arial, serif;
-    font-size: 20pt;
-    color: #0001E0;
-    margin-bottom: .5em;
-    margin-top: 0.5em;
-    display: block;
+  font-family: 'Source Sans Pro', Helvetica, Arial, serif;
+  font-size: 20pt;
+  color: #0001e0;
+  margin-bottom: 0.5em;
+  margin-top: 0.5em;
+  display: block;
 }
 
-.warning{
-    color: rgb( 240, 20, 20 )
-    }  
+.warning {
+  color: rgb(240, 20, 20);
+}
 
 a {
-    color: #0080FF;
-    text-decoration: none;
-    -webkit-transition: color 0.2s ease-in-out;
-    -moz-transition: color 0.2s ease-in-out;
-    -o-transition: color 0.2s ease-in-out;
-    -ms-transition: color 0.2s ease-in-out;
-    transition: color 0.2s ease-in-out;
+  color: #0080ff;
+  text-decoration: none;
+  -webkit-transition: color 0.2s ease-in-out;
+  -moz-transition: color 0.2s ease-in-out;
+  -o-transition: color 0.2s ease-in-out;
+  -ms-transition: color 0.2s ease-in-out;
+  transition: color 0.2s ease-in-out;
 }
 a:hover {
-    color: #8C0028;
+  color: #8c0028;
 }
 
-li li{
-    font-size:14px;
+li li {
+  font-size: 14px;
 }
 
-div.danger {    
-    background-color: #F7A7AA;
-    border-color: #F1595F;
-    border: 2px solid #F1595F;
-    border-radius: 5px;
-    padding-top: 0.5ex;
-    padding-bottom: 0.5ex;
-    padding-left: 0.5em;
-    }
-
-div.warn {    
-background-color: #FBD1A7;
-border-color: #F9A65A;
-border: 2px solid #F9A65A;
-border-radius: 5px;
-padding-top: 0.5ex;
-padding-bottom: 0.5ex;
-padding-left: 0.5em;
+div.danger {
+  background-color: #f7a7aa;
+  border-color: #f1595f;
+  border: 2px solid #f1595f;
+  border-radius: 5px;
+  padding-top: 0.5ex;
+  padding-bottom: 0.5ex;
+  padding-left: 0.5em;
 }
 
-div.info {    
-background-color: #A6CBE9;
-border-color: #599AD3;
-border: 2px solid #599AD3;
-border-radius: 5px;
-padding-top: 0.5ex;
-padding-bottom: 0.5ex;
-padding-left: 0.5em;
+div.warn {
+  background-color: #fbd1a7;
+  border-color: #f9a65a;
+  border: 2px solid #f9a65a;
+  border-radius: 5px;
+  padding-top: 0.5ex;
+  padding-bottom: 0.5ex;
+  padding-left: 0.5em;
 }
 
-div.success {    
-background-color: #B9E0B0;
-border-color: #79C36A;
-border: 2px solid #79C36A;
-border-radius: 5px;
-padding-top: 0.5ex;
-padding-bottom: 0.5ex;
-padding-left: 0.5em;
+div.info {
+  background-color: #a6cbe9;
+  border-color: #599ad3;
+  border: 2px solid #599ad3;
+  border-radius: 5px;
+  padding-top: 0.5ex;
+  padding-bottom: 0.5ex;
+  padding-left: 0.5em;
+}
+
+div.success {
+  background-color: #b9e0b0;
+  border-color: #79c36a;
+  border: 2px solid #79c36a;
+  border-radius: 5px;
+  padding-top: 0.5ex;
+  padding-bottom: 0.5ex;
+  padding-left: 0.5em;
 }
 
 table a:link {
-    color: #666;
-    font-weight: bold;
-    text-decoration:none;
+  color: #666;
+  font-weight: bold;
+  text-decoration: none;
 }
 table a:visited {
-    color: #999999;
-    font-weight:bold;
-    text-decoration:none;
+  color: #999999;
+  font-weight: bold;
+  text-decoration: none;
 }
 table a:active,
 table a:hover {
-    color: #bd5a35;
-    text-decoration:underline;
+  color: #bd5a35;
+  text-decoration: underline;
 }
 table {
-    font-family:"Source Sans Pro", Helvetica, Arial, serif;
-    color:#666;
-    font-size:14px;
-    text-shadow: 1px 1px 0px #fff;
-    background:#eaebec;
-    margin:20px;
-    border:#ccc 1px solid;
-    border-spacing: 0;
-    -moz-border-radius:3px;
-    -webkit-border-radius:3px;
-    border-radius:3px;
+  font-family: 'Source Sans Pro', Helvetica, Arial, serif;
+  color: #666;
+  font-size: 14px;
+  text-shadow: 1px 1px 0px #fff;
+  background: #eaebec;
+  margin: 20px;
+  border: #ccc 1px solid;
+  border-spacing: 0;
+  -moz-border-radius: 3px;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
 
-    -moz-box-shadow: 0 1px 2px #d1d1d1;
-    -webkit-box-shadow: 0 1px 2px #d1d1d1;
-    box-shadow: 0 1px 2px #d1d1d1;
+  -moz-box-shadow: 0 1px 2px #d1d1d1;
+  -webkit-box-shadow: 0 1px 2px #d1d1d1;
+  box-shadow: 0 1px 2px #d1d1d1;
 }
 table th {
-    padding:21px 25px 22px 25px;
-    border-top:1px solid #fafafa;
-    border-bottom:1px solid #e0e0e0;
+  padding: 21px 25px 22px 25px;
+  border-top: 1px solid #fafafa;
+  border-bottom: 1px solid #e0e0e0;
 
-    background: #ededed;
-    background: -webkit-gradient(linear, left top, left bottom, from(#ededed), to(#ebebeb));
-    background: -moz-linear-gradient(top,  #ededed,  #ebebeb);
+  background: #ededed;
+  background: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#ededed),
+    to(#ebebeb)
+  );
+  background: -moz-linear-gradient(top, #ededed, #ebebeb);
 }
-table th:first-child{
-    text-align: left;
-    padding-left:20px;
+table th:first-child {
+  text-align: left;
+  padding-left: 20px;
 }
-table tr:first-child th:first-child{
-    -moz-border-radius-topleft:3px;
-    -webkit-border-top-left-radius:3px;
-    border-top-left-radius:3px;
+table tr:first-child th:first-child {
+  -moz-border-radius-topleft: 3px;
+  -webkit-border-top-left-radius: 3px;
+  border-top-left-radius: 3px;
 }
-table tr:first-child th:last-child{
-    -moz-border-radius-topright:3px;
-    -webkit-border-top-right-radius:3px;
-    border-top-right-radius:3px;
+table tr:first-child th:last-child {
+  -moz-border-radius-topright: 3px;
+  -webkit-border-top-right-radius: 3px;
+  border-top-right-radius: 3px;
 }
-table tr{
-    text-align: center;
-    padding-left:20px;
+table tr {
+  text-align: center;
+  padding-left: 20px;
 }
-table tr td:first-child{
-    text-align: left;
-    padding-left:20px;
-    border-left: 0;
+table tr td:first-child {
+  text-align: left;
+  padding-left: 20px;
+  border-left: 0;
 }
 table tr td {
-    padding:18px;
-    border-top: 1px solid #ffffff;
-    border-bottom:1px solid #e0e0e0;
-    border-left: 1px solid #e0e0e0;
+  padding: 18px;
+  border-top: 1px solid #ffffff;
+  border-bottom: 1px solid #e0e0e0;
+  border-left: 1px solid #e0e0e0;
 
-    background: #fafafa;
-    background: -webkit-gradient(linear, left top, left bottom, from(#fbfbfb), to(#fafafa));
-    background: -moz-linear-gradient(top,  #fbfbfb,  #fafafa);
+  background: #fafafa;
+  background: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#fbfbfb),
+    to(#fafafa)
+  );
+  background: -moz-linear-gradient(top, #fbfbfb, #fafafa);
 }
 
 table tr:nth-child(2n) td {
-    background: #f6f6f6;
-    background: -webkit-gradient(linear, left top, left bottom, from(#f8f8f8), to(#f6f6f6));
-    background: -moz-linear-gradient(top, #f8f8f8, #f6f6f6);
+  background: #f6f6f6;
+  background: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#f8f8f8),
+    to(#f6f6f6)
+  );
+  background: -moz-linear-gradient(top, #f8f8f8, #f6f6f6);
 }
 
-table tr:last-child td{
-    border-bottom:0;
+table tr:last-child td {
+  border-bottom: 0;
 }
-table tr:last-child td:first-child{
-    -moz-border-radius-bottomleft:3px;
-    -webkit-border-bottom-left-radius:3px;
-    border-bottom-left-radius:3px;
+table tr:last-child td:first-child {
+  -moz-border-radius-bottomleft: 3px;
+  -webkit-border-bottom-left-radius: 3px;
+  border-bottom-left-radius: 3px;
 }
-table tr:last-child td:last-child{
-    -moz-border-radius-bottomright:3px;
-    -webkit-border-bottom-right-radius:3px;
-    border-bottom-right-radius:3px;
+table tr:last-child td:last-child {
+  -moz-border-radius-bottomright: 3px;
+  -webkit-border-bottom-right-radius: 3px;
+  border-bottom-right-radius: 3px;
 }
-table tr:hover td{
-    background: #f2f2f2;
-    background: -webkit-gradient(linear, left top, left bottom, from(#f2f2f2), to(#f0f0f0));
-    background: -moz-linear-gradient(top,  #f2f2f2,  #f0f0f0);	
+table tr:hover td {
+  background: #f2f2f2;
+  background: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#f2f2f2),
+    to(#f0f0f0)
+  );
+  background: -moz-linear-gradient(top, #f2f2f2, #f0f0f0);
 }
-
 
 caption {
-    display: table-caption;
-    font-weight: 700;
+  display: table-caption;
+  font-weight: 700;
 }
 
 figure {
-    display: inline-block;
-    position: relative;
-    margin: 1em 0 2em;
+  display: inline-block;
+  position: relative;
+  margin: 1em 0 2em;
 }
 figcaption {
-    font-style: italic;
-    text-align: center;
-    background: white;
-    color: #666;
-    position: absolute;
-    left: 0;
-    bottom: -24px;
-    width: 98%;
-    padding: 1%;
-    -webkit-transition: all 0.2s ease-in-out;
-    -moz-transition: all 0.2s ease-in-out;
-    -o-transition: all 0.2s ease-in-out;
-    -ms-transition: all 0.2s ease-in-out;
-    transition: all 0.2s ease-in-out;
+  font-style: italic;
+  text-align: center;
+  background: white;
+  color: #666;
+  position: absolute;
+  left: 0;
+  bottom: -24px;
+  width: 98%;
+  padding: 1%;
+  -webkit-transition: all 0.2s ease-in-out;
+  -moz-transition: all 0.2s ease-in-out;
+  -o-transition: all 0.2s ease-in-out;
+  -ms-transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
 }
 
 .prompt.input_prompt {
-    color: rgba(0,0,0,0.5);
+  color: rgba(0, 0, 0, 0.5);
 }
 
 .cell.command_mode.selected {
-    border-color: rgba(0,0,0,0.1);
+  border-color: rgba(0, 0, 0, 0.1);
 }
 
 .cell.edit_mode.selected {
-    border-color: rgba(0,0,0,0.15);
-    box-shadow: 0px 0px 5px #f0f0f0;
-    -webkit-box-shadow: 0px 0px 5px #f0f0f0;
+  border-color: rgba(0, 0, 0, 0.15);
+  box-shadow: 0px 0px 5px #f0f0f0;
+  -webkit-box-shadow: 0px 0px 5px #f0f0f0;
 }
 
 div.output_scroll {
-    -webkit-box-shadow: inset 0 2px 8px rgba(0,0,0,0.1);
-    box-shadow: inset 0 2px 8px rgba(0,0,0,0.1);
-    border-radious: 2px;
+  -webkit-box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.1);
+  border-radius: 2px;
 }
 
 #menubar .navbar-inner {
-    background: #fff;
-    -webkit-box-shadow: none;
-    box-shadow: none;
-    border-radius: 0;
-    border: none;
-    font-family: "Source Sans Pro", Helvetica, Arial, serif;
-    font-weight: 400;
+  background: #fff;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  border-radius: 0;
+  border: none;
+  font-family: 'Source Sans Pro', Helvetica, Arial, serif;
+  font-weight: 400;
 }
 
 .navbar-fixed-top .navbar-inner,
 .navbar-static-top .navbar-inner {
-    box-shadow: none;
-    -webkit-box-shadow: none;
-    border: none;
+  box-shadow: none;
+  -webkit-box-shadow: none;
+  border: none;
 }
 
 div#notebook_panel {
-    box-shadow: none;
-    -webkit-box-shadow: none;
-    border-top: none;
+  box-shadow: none;
+  -webkit-box-shadow: none;
+  border-top: none;
 }
 
 div#notebook {
-    border-top: 1px solid rgba(0,0,0,0.15);
+  border-top: 1px solid rgba(0, 0, 0, 0.15);
 }
 
 #menubar .navbar .navbar-inner,
 .toolbar-inner {
-    padding-left: 0;
-    padding-right: 0;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 #checkpoint_status,
 #autosave_status {
-    color: rgba(0,0,0,0.5);
+  color: rgba(0, 0, 0, 0.5);
 }
 
 #header {
-    font-family: "Source Sans Pro", Helvetica, Arial, serif;
+  font-family: 'Source Sans Pro', Helvetica, Arial, serif;
 }
 
 #notebook_name {
-    font-weight: 200;
+  font-weight: 200;
 }
 
 /* 
@@ -335,9 +358,9 @@ div#notebook {
     background for each Bootstrap button type
 */
 #site * .btn {
-    background: #fafafa;
-    -webkit-box-shadow: none;
-    box-shadow: none;
+  background: #fafafa;
+  -webkit-box-shadow: none;
+  box-shadow: none;
 }
 
 </style>

--- a/python/styles/style.css
+++ b/python/styles/style.css
@@ -1,205 +1,206 @@
 <style>
-@import url('http://fonts.googleapis.com/css?family=Source+Sans+Pro');
-@import url('http://fonts.googleapis.com/css?family=Source+Code+Pro');
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro');
+@import url('https://fonts.googleapis.com/css?family=Source+Code+Pro');
 
 body {
-    -webkit-font-smoothing: antialiased;
-    font-family: "Source Sans Pro", Helvetica, Arial, Verdana, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro', Helvetica, Arial, Verdana, sans-serif;
 }
 
-
-div.cell{
-    width:768px;
-    margin-left:10% !important;
-    margin-right:auto;
+div.cell {
+  width: 768px;
+  margin-left: 10% !important;
+  margin-right: auto;
 }
 h1 {
-    font-family: "Source Sans Pro", ,Helvetica, Arial, serif;
+  font-family: 'Source Sans Pro', Helvetica, Arial, serif;
 }
-h4{
-    font-family: "Source Sans Pro", Helvetica, Arial, serif;
-	margin-top:12px;
-    margin-bottom: 3px;
-   }
-div.text_cell_render{
-    font-family: "Source Sans Pro", Helvetica, Arial, sans-serif;
-    line-height: 125%;
-    font-size: 110%;
-    width:768px;
-    margin-left:auto;
-    margin-right:auto;
+h4 {
+  font-family: 'Source Sans Pro', Helvetica, Arial, serif;
+  margin-top: 12px;
+  margin-bottom: 3px;
 }
-.CodeMirror{
-        font-family: "Source Code Pro", source-code-pro, Consolas, monospace;
+div.text_cell_render {
+  font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif;
+  line-height: 125%;
+  font-size: 110%;
+  width: 768px;
+  margin-left: auto;
+  margin-right: auto;
 }
-.prompt{
-    display: None;
+.CodeMirror {
+  font-family: 'Source Code Pro', source-code-pro, Consolas, monospace;
+}
+.prompt {
+  display: None;
 }
 .text_cell_render h5 {
-    font-family: "Source Sans Pro", Helvetica, Arial, serif;
-    font-size: 20pt;
-    color: #0001E0;
-    margin-bottom: .5em;
-    margin-top: 0.5em;
-    display: block;
+  font-family: 'Source Sans Pro', Helvetica, Arial, serif;
+  font-size: 20pt;
+  color: #0001e0;
+  margin-bottom: 0.5em;
+  margin-top: 0.5em;
+  display: block;
 }
 
-.warning{
-    color: rgb( 240, 20, 20 )
-    }  
+.warning {
+  color: rgb(240, 20, 20);
+}
 
 a {
-    color: #0D68AE;
-    text-decoration: none;
-    -webkit-transition: color 0.2s ease-in-out;
-    -moz-transition: color 0.2s ease-in-out;
-    -o-transition: color 0.2s ease-in-out;
-    -ms-transition: color 0.2s ease-in-out;
-    transition: color 0.2s ease-in-out;
+  color: #0d68ae;
+  text-decoration: none;
+  -webkit-transition: color 0.2s ease-in-out;
+  -moz-transition: color 0.2s ease-in-out;
+  -o-transition: color 0.2s ease-in-out;
+  -ms-transition: color 0.2s ease-in-out;
+  transition: color 0.2s ease-in-out;
 }
 a:hover {
-    color: #54ABE0;
+  color: #54abe0;
 }
 
 table {
-    border: 0px solid rgba(0, 0, 0, 0.25);
-    border-collapse: collapse;
-    display: table;
-    empty-cells: hide;
-    margin: -1px 0 1.3125em;
-    padding: 0;
-    table-layout: fixed;
+  border: 0px solid rgba(0, 0, 0, 0.25);
+  border-collapse: collapse;
+  display: table;
+  empty-cells: hide;
+  margin: -1px 0 1.3125em;
+  padding: 0;
+  table-layout: fixed;
 }
 caption {
-    display: table-caption;
-    font-weight: 700;
+  display: table-caption;
+  font-weight: 700;
 }
 col {
-    display: table-column;
+  display: table-column;
 }
 colgroup {
-    display: table-column-group;
+  display: table-column-group;
 }
 tbody {
-    display: table-row-group;
+  display: table-row-group;
 }
 tfoot {
-    display: table-footer-group;
+  display: table-footer-group;
 }
 thead {
-    display: table-header-group;
+  display: table-header-group;
 }
-td, th {
-    display: table-cell;
+td,
+th {
+  display: table-cell;
 }
 tr {
-    display: table-row;
+  display: table-row;
 }
-table th, table td {
-    font-size: 1.1em;
-    line-height: 23px;
-    padding: 0 1em;
+table th,
+table td {
+  font-size: 1.1em;
+  line-height: 23px;
+  padding: 0 1em;
 }
 table thead {
-    background: rgba(0, 0, 0, 0.15);
-    border: 0px solid rgba(0, 0, 0, 0.15);
-    border-bottom: 0px solid rgba(0, 0, 0, 0.2);
+  background: rgba(0, 0, 0, 0.15);
+  border: 0px solid rgba(0, 0, 0, 0.15);
+  border-bottom: 0px solid rgba(0, 0, 0, 0.2);
 }
 table tbody {
-    background: #FFFFFF;
+  background: #ffffff;
 }
 table tfoot {
-    background: rgba(0, 0, 0, 0.15);
-    border: 0px solid rgba(0, 0, 0, 0.15);
-    border-top: 0px solid rgba(0, 0, 0, 0.2);
+  background: rgba(0, 0, 0, 0.15);
+  border: 0px solid rgba(0, 0, 0, 0.15);
+  border-top: 0px solid rgba(0, 0, 0, 0.2);
 }
 
 figure {
-    display: inline-block;
-    position: relative;
-    margin: 1em 0 2em;
+  display: inline-block;
+  position: relative;
+  margin: 1em 0 2em;
 }
 figcaption {
-    font-style: italic;
-    text-align: center;
-    background: white;
-    color: #666;
-    position: absolute;
-    left: 0;
-    bottom: -24px;
-    width: 98%;
-    padding: 1%;
-    -webkit-transition: all 0.2s ease-in-out;
-    -moz-transition: all 0.2s ease-in-out;
-    -o-transition: all 0.2s ease-in-out;
-    -ms-transition: all 0.2s ease-in-out;
-    transition: all 0.2s ease-in-out;
+  font-style: italic;
+  text-align: center;
+  background: white;
+  color: #666;
+  position: absolute;
+  left: 0;
+  bottom: -24px;
+  width: 98%;
+  padding: 1%;
+  -webkit-transition: all 0.2s ease-in-out;
+  -moz-transition: all 0.2s ease-in-out;
+  -o-transition: all 0.2s ease-in-out;
+  -ms-transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
 }
 
 .prompt.input_prompt {
-    color: rgba(0,0,0,0.5);
+  color: rgba(0, 0, 0, 0.5);
 }
 
 .cell.command_mode.selected {
-    border-color: rgba(0,0,0,0.1);
+  border-color: rgba(0, 0, 0, 0.1);
 }
 
 .cell.edit_mode.selected {
-    border-color: rgba(0,0,0,0.15);
-    box-shadow: 0px 0px 5px #f0f0f0;
-    -webkit-box-shadow: 0px 0px 5px #f0f0f0;
+  border-color: rgba(0, 0, 0, 0.15);
+  box-shadow: 0px 0px 5px #f0f0f0;
+  -webkit-box-shadow: 0px 0px 5px #f0f0f0;
 }
 
 div.output_scroll {
-    -webkit-box-shadow: inset 0 2px 8px rgba(0,0,0,0.1);
-    box-shadow: inset 0 2px 8px rgba(0,0,0,0.1);
-    border-radious: 2px;
+  -webkit-box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.1);
+  border-radius: 2px;
 }
 
 #menubar .navbar-inner {
-    background: #fff;
-    -webkit-box-shadow: none;
-    box-shadow: none;
-    border-radius: 0;
-    border: none;
-    font-family: "Source Sans Pro", Helvetica, Arial, serif;
-    font-weight: 400;
+  background: #fff;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  border-radius: 0;
+  border: none;
+  font-family: 'Source Sans Pro', Helvetica, Arial, serif;
+  font-weight: 400;
 }
 
 .navbar-fixed-top .navbar-inner,
 .navbar-static-top .navbar-inner {
-    box-shadow: none;
-    -webkit-box-shadow: none;
-    border: none;
+  box-shadow: none;
+  -webkit-box-shadow: none;
+  border: none;
 }
 
 div#notebook_panel {
-    box-shadow: none;
-    -webkit-box-shadow: none;
-    border-top: none;
+  box-shadow: none;
+  -webkit-box-shadow: none;
+  border-top: none;
 }
 
 div#notebook {
-    border-top: 1px solid rgba(0,0,0,0.15);
+  border-top: 1px solid rgba(0, 0, 0, 0.15);
 }
 
 #menubar .navbar .navbar-inner,
 .toolbar-inner {
-    padding-left: 0;
-    padding-right: 0;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 #checkpoint_status,
 #autosave_status {
-    color: rgba(0,0,0,0.5);
+  color: rgba(0, 0, 0, 0.5);
 }
 
 #header {
-    font-family: "Source Sans Pro", Helvetica, Arial, serif;
+  font-family: 'Source Sans Pro', Helvetica, Arial, serif;
 }
 
 #notebook_name {
-    font-weight: 200;
+  font-weight: 200;
 }
 
 /* 
@@ -207,9 +208,9 @@ div#notebook {
     background for each Bootstrap button type
 */
 #site * .btn {
-    background: #fafafa;
-    -webkit-box-shadow: none;
-    box-shadow: none;
+  background: #fafafa;
+  -webkit-box-shadow: none;
+  box-shadow: none;
 }
 
 </style>


### PR DESCRIPTION
👋 Hi

This is a simple fix. I had an error when visiting `https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/python/Matplotlib_Plotting.ipynb`. As, the code examples were hidden. The reason stated in the console was:

`Mixed Content: The page at 'https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/python/Matplotlib_Plotting.ipynb` was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Source+Sans+Pro'. This request has been blocked; the content must be served over HTTPS.`

So, I replaced the `http://fonts.googleapis.com` with `https://fonts.googleapis.com` and that should do the trick (it cannot be checked on localhost). I also ran an automatic linter on the css code and deleted a couple errors.