### PR TITLE
Add more installation guide for circuit plotting

### DIFF
--- a/examples/quantum-gates.ipynb
+++ b/examples/quantum-gates.ipynb
@@ -17,10 +17,14 @@
     "\n",
     "For more information about QuTiP see [http://qutip.org](http://qutip.org)\n",
     "\n",
-    "**Note: The circuit image visualizations require [ImageMagick](https://imagemagick.org/index.php) for display.**\n",
+    "#### Installation: \n",
+    "The circuit image visualization requires LaTeX and [ImageMagick](https://imagemagick.org/index.php) for display. The module automatically process the LaTeX code for plotting the circuit, generate the pdf and convert it to the png format.\n",
+    "On Mac and Linux, ImageMagick can be easily installed with the command `conda install imagemagick` if you have conda installed.\n",
+    "Otherwise, please follow the installation instructions on the ImageMagick documentation.\n",
     "\n",
-    "ImageMagick can be easily installed with the command `conda install imagemagick` if you have conda installed.\n",
-    "Otherwise, please follow the installation instructions on the ImageMagick documentation."
+    "On windows, you need to download and install ImageMagick installer. In addition, you also need [perl](https://www.perl.org/get.html) (for pdfcrop) and [Ghostscript](https://www.ghostscript.com/download/gsdnld.html) (additional dependency of ImageMagick for png conversion).\n",
+    "\n",
+    "To test if the installation is complete, try the following three commands working correctly in Command Prompt: `pdflatex`, `pdfcrop` and `magick anypdf.pdf antpdf.png`, where `anypdf.pdf` is any pdf file you have."
    ]
   },
   {
@@ -2088,9 +2092,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (qutip)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "qutip"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2102,7 +2106,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I recently installed qutip on a new laptop. There are several tricks for getting the circuit plotting work that are unclear in the current notebook. I improved the installation guide:


#### Installation: 
The circuit image visualization requires LaTeX and [ImageMagick](https://imagemagick.org/index.php) for display. The module automatically process the LaTeX code for plotting the circuit, generate the pdf and convert it to the png format. On Mac and Linux, ImageMagick can be easily installed with the command `conda install imagemagick` if you have conda installed. Otherwise, please follow the installation instructions on the ImageMagick documentation.

On windows, you need to download and install ImageMagick installer. In addition, you also need [perl](https://www.perl.org/get.html) (for pdfcrop) and [Ghostscript](https://www.ghostscript.com/download/gsdnld.html) (additional dependency of ImageMagick for png conversion).

If you want to check whether all dependencies are installed, see if the following three commands work correctly: `pdflatex`, `pdfcrop` and `magick anypdf.pdf antpdf.png`, where `anypdf.pdf` is any pdf file you have.